### PR TITLE
Add configurable support for setting last modified file/directory timestamps (issue #19)

### DIFF
--- a/doc/annotated_wsgidav.conf
+++ b/doc/annotated_wsgidav.conf
@@ -147,6 +147,20 @@ dir_browser = {
 propsmanager = True
 
 
+### Optional additional live property modification
+# Note: by default live properties like file size and last-modified time are
+# read-only, but that can be overriden here if the underlying DAV provider
+# supports it. For now only the FileSystemProvider supports it and only namely
+# changes to the last-modified timestamp. Enable it with the mutable_live_props
+# list as below to allow clients to use the utime system call or e.g. the
+# touch or cp / rsync commands with the preserve-timestamp flags on a mounted
+# DAV share.
+# Please note that the timestamp is set on the actual file or directory, so it
+# is persistent even for in-memory property managers. It should also be noted
+# that mutable last-modified may not be compliant with the RFC 4918.
+#mutable_live_props = ["{DAV:}getlastmodified"]
+
+
 #===============================================================================
 # Lock Manager
 #

--- a/wsgidav.conf.sample
+++ b/wsgidav.conf.sample
@@ -115,6 +115,12 @@ dir_browser = {
 propsmanager = True
 
 
+### Optional additional live property modification
+# Enable to allow clients to use e.g. the touch or cp / rsync commands with the
+# preserve-timestamp flags in a mounted DAV share (may be RFC4918 incompliant)
+#mutable_live_props = ["{DAV:}getlastmodified"]
+
+
 #===============================================================================
 # Lock Manager
 #

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -158,6 +158,13 @@ class FileResource(DAVNonCollection):
                                                      withChildren=True)
 
 
+    def setLastModified(self, destPath, timeStamp, dryRun):
+        """Set last modified time for destPath to timeStamp on epoch-format"""
+        # Translate time from RFC 1123 to seconds since epoch format
+        secs = util.parseTimeString(timeStamp)
+        if not dryRun:
+            os.utime(self._filePath, (secs, secs))
+        return True
 
 
 #===============================================================================
@@ -327,6 +334,13 @@ class FolderResource(DAVCollection):
                                                      withChildren=True)
 
 
+    def setLastModified(self, destPath, timeStamp, dryRun):
+        """Set last modified time for destPath to timeStamp on epoch-format"""
+        # Translate time from RFC 1123 to seconds since epoch format
+        secs = util.parseTimeString(timeStamp)
+        if not dryRun:
+            os.utime(self._filePath, (secs, secs))
+        return True
 
 
 #===============================================================================


### PR DESCRIPTION
Add configurable support for setting last modified file/directory timestamps. E.g. when a user mounts a DAV share and runs touch or copy/rsync commands with preserve timestamps flags to destination files or directories there. Not enabled by default since it may not be compliant with RFC 4918.

This is a proposed patch for issue #19 .

Tested to work as expected on files and directories with the new mutable_live_props configuration unset, set to [] and 
mutable_live_props = ["{DAV:}getlastmodified"] 

Please comment or consider for merging.

Cheers, Jonas