### PR TITLE
Fix typo in requeriments-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pytest-cov~=1.8
 sphinx~=1.3
 sphinxcontrib-napoleon~=0.3
 tox~=2.0
-WebTest=~2.0
+WebTest~=2.0


### PR DESCRIPTION
WebTest dependency uses =~ to specify the version but it should be ~=