### PR TITLE
Ensure owner property of lock manager is always bytes

### DIFF
--- a/tests/test_lock_manager.py
+++ b/tests/test_lock_manager.py
@@ -15,7 +15,7 @@ from wsgidav import lock_manager, lock_storage
 class BasicTest(unittest.TestCase):
     """Test lock_manager.LockManager()."""
     principal = "Joe Tester"
-    owner = "joe.tester@example.com"
+    owner = b'joe.tester@example.com'
     root = "/dav/res"
     timeout = 10 * 60  # Default lock timeout 10 minutes
 


### PR DESCRIPTION
This fixes the lock manager test for python2 and python3