### PR TITLE
Fix KeyError for non-matching share.

### DIFF
--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -273,12 +273,12 @@ class WsgiDAVApp(object):
                 share = r
                 break
         
-        share_data = self.providerMap.get(share)
-        
         # Note: we call the next app, even if provider is None, because OPTIONS 
         #       must still be handled.
         #       All other requests will result in '404 Not Found'  
-        environ["wsgidav.provider"] = share_data['provider']
+        if share is not None:
+            share_data = self.providerMap.get(share)
+            environ["wsgidav.provider"] = share_data['provider']
         # TODO: test with multi-level realms: 'aa/bb'
         # TODO: test security: url contains '..'
         


### PR DESCRIPTION
When getting a path that doesn't match any provider, an unhelpful error is returned:

```shell
Traceback (most recent call last):
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 86, in run
    self.finish_response()
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 131, in finish_response
    self.close()
  File "/usr/lib/python2.7/wsgiref/simple_server.py", line 33, in close
    self.status.split(' ',1)[0], self.bytes_sent
AttributeError: 'NoneType' object has no attribute 'split'
127.0.0.1 - - [09/Sep/2016 15:27:45] "GET / HTTP/1.1" 500 59
```

This is hiding a `KeyError` when `share` is not in `self.providerMap`:
```python
         share_data = self.providerMap.get(share)
         
         # Note: we call the next app, even if provider is None, because OPTIONS 
         #       must still be handled.
         #       All other requests will result in '404 Not Found'  
-        environ["wsgidav.provider"] = share_data['provider']
```

With this patch a 404 is returned.