### PR TITLE
Use defusedxml for safe xml parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGES
 
 2.0.1 / Unreleased
 ==================
--
+- Wrap xml libraries with the equivalent defusedxml packages (thanks Tom Viner)
+
 
 2.0.0 / 2016-10-02
 ==================
@@ -62,7 +63,7 @@ CHANGES
 - Files are always stored in binary mode.
 - Port and hostname can now be specified in config file (before: command line only).
 - New option for dir_browser: 'msSharepointUrls' will prepend 'ms-word:ofe|u|' to URL for MS Offce documents.
-- New option 'add_header_MS_Author_Via = True' to support editing with Microsoft Office 
+- New option 'add_header_MS_Author_Via = True' to support editing with Microsoft Office
 - FilesystemProvider expands variables like '~', '$Name' and '%NAME%' in folder paths (i.e. '~/foo' -> '/Users/joe/foo')
 - Issue #55 Failure operating with litmus test suite, Mac OS X WebDAV Client, Windows 7 (thanks to Ben Allums)
 - Fixed issue #48 Allow the dirbrowser to be configured from the config file (thanks to Herman Grecco)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cherrypy~=7.1
 distribute==0.7.3
 PyInstaller==3.2
+defusedxml

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ if not "HOME" in os.environ and  "HOMEPATH" in os.environ:
 #   2. users may prefer another server
 #   3. there may already cherrypy versions installed
 
-install_requires = [#"cherrypy",
+install_requires = ["defusedxml",
+                    #"cherrypy",
                     #"lxml",
                     ]
 tests_require = ["cherrypy",

--- a/wsgidav/xml_tools.py
+++ b/wsgidav/xml_tools.py
@@ -20,13 +20,18 @@ from wsgidav import compat
 # Import XML support
 useLxml = False
 try:
-    from lxml import etree
+    # lxml with safe defaults
+    from defusedxml.lxml import etree
     useLxml = True
     _ElementType = etree._Element
 except ImportError:
-    # Try xml module (Python 2.5 or later)
-    from xml.etree import ElementTree as etree
-    _ElementType = etree.Element
+    # Try xml module (Python 2.5 or later) with safe defaults
+    from defusedxml import ElementTree as etree
+    # defusedxml doesn't define these non-parsing related objects
+    from xml.etree.ElementTree import Element, SubElement, tostring
+    etree.Element = _ElementType = Element
+    etree.SubElement = SubElement
+    etree.tostring = tostring
     # print("WARNING: Could not import lxml: using xml instead (slower).")
     # print("         Consider installing lxml https://pypi.python.org/pypi/lxml.")
 


### PR DESCRIPTION
By default `lxml.etree` and `xml.etree` are not safe when parsing untrusted user input. This PR uses [defusedxml](https://pypi.python.org/pypi/defusedxml) to wraps those libraries, applying safe defaults, thus preventing several attack vectors.