### PR TITLE
Manual pep8 fixes

### DIFF
--- a/wsgidav/addons/couch_property_manager.py
+++ b/wsgidav/addons/couch_property_manager.py
@@ -64,7 +64,7 @@ class CouchPropertyManager(object):
                      (self.db, self.couch.version()))
 
         # Ensure that we have a permanent view
-        if not "_design/properties" in self.db:
+        if "_design/properties" not in self.db:
             map = """
             function(doc) {
                 if(doc.type == 'properties') {
@@ -74,11 +74,12 @@ class CouchPropertyManager(object):
             """
             designDoc = {
                 "_id": "_design/properties",
-#                "_rev": "42351258",
+                # "_rev": "42351258",
                 "language": "javascript",
                 "views": {
                     "titles": {
-                        "map": "function(doc) { emit(null, { 'id': doc._id, 'title': doc.title }); }"
+                        "map": ("function(doc) { emit(null, { 'id': doc._id, "
+                            "'title': doc.title }); }")
                     },
                     # http://127.0.0.1:5984/wsgidav_props/_design/properties/_view/by_url
                     "by_url": {

--- a/wsgidav/addons/hg_dav_provider.py
+++ b/wsgidav/addons/hg_dav_provider.py
@@ -88,7 +88,7 @@ try:
     import mercurial.ui
     from mercurial.__version__ import version as hgversion
     from mercurial import commands, hg
-    #from mercurial import util as hgutil
+    # from mercurial import util as hgutil
 except ImportError:
     print("Could not import Mercurial API. Try 'easy_install -U mercurial'.", file=sys.stderr)
     raise
@@ -111,8 +111,8 @@ class HgResource(_DAVResource):
         self.rev = rev
         self.localHgPath = localHgPath
         self.absFilePath = self._getFilePath()
-        assert not "\\" in self.localHgPath
-        assert not "/" in self.absFilePath
+        assert "\\" not in self.localHgPath
+        assert "/" not in self.absFilePath
 
         if isCollection:
             self.fctx = None
@@ -123,8 +123,10 @@ class HgResource(_DAVResource):
             # rev=<int>: Revision ID
             wdctx = self.provider.repo[self.rev]
             self.fctx = wdctx[self.localHgPath]
-#        util.status("HgResource: path=%s, rev=%s, localHgPath=%s, fctx=%s" % (self.path, self.rev, self.localHgPath, self.fctx))
-#        util.status("HgResource: name=%s, dn=%s, abspath=%s" % (self.name, self.getDisplayName(), self.absFilePath))
+#        util.status("HgResource: path=%s, rev=%s, localHgPath=%s, fctx=%s" % (
+#            self.path, self.rev, self.localHgPath, self.fctx))
+#        util.status("HgResource: name=%s, dn=%s, abspath=%s" % (
+#            self.name, self.getDisplayName(), self.absFilePath))
 
     def _getFilePath(self, *addParts):
         parts = self.localHgPath.split("/")
@@ -161,9 +163,9 @@ class HgResource(_DAVResource):
         return util.guessMimeType(self.path)
 
     def getCreationDate(self):
-#        statresults = os.stat(self._filePath)
-#        return statresults[stat.ST_CTIME]
-        return None # TODO
+        # statresults = os.stat(self._filePath)
+        # return statresults[stat.ST_CTIME]
+        return None  # TODO
 
     def getDisplayName(self):
         if self.isCollection or self.fctx.filerev() is None:
@@ -171,7 +173,8 @@ class HgResource(_DAVResource):
         return "%s@%s" % (self.name, self.fctx.filerev())
 
     def getEtag(self):
-        return md5(self.path).hexdigest() + "-" + compat.to_native(self.getLastModified()) + "-" + str(self.getContentLength())
+        return (md5(self.path).hexdigest() + "-" + compat.to_native(self.getLastModified()) + "-"
+            + str(self.getContentLength()))
 
     def getLastModified(self):
         if self.isCollection:
@@ -186,7 +189,7 @@ class HgResource(_DAVResource):
         assert self.isCollection
         cache = self.environ["wsgidav.hg.cache"][compat.to_native(self.rev)]
         dirinfos = cache["dirinfos"]
-        if not dirinfos.has_key(self.localHgPath):
+        if self.localHgPath not in dirinfos:
             return []
         return dirinfos[self.localHgPath][0] + dirinfos[self.localHgPath][1]
 #        return self.provider._listMembers(self.path)
@@ -543,7 +546,7 @@ class HgResourceProvider(DAVProvider):
                  }
         caches[compat.to_native(rev)] = cache
         util.note("_getRepoInfo(%s) took %.3f" % (rev, time.time() - start_time)
-#                  , var=cache
+                  # , var=cache
                   )
         return cache
 
@@ -552,7 +555,7 @@ class HgResourceProvider(DAVProvider):
 #        """Return a list of all non-collection members"""
 #        # Pattern for direct members:
 #        glob = "glob:" + os.path.join(path, "*").lstrip("/")
-##        print(glob)
+#        print(glob)
 #        self.ui.pushbuffer()
 #        commands.status(self.ui, self.repo,
 #                        glob,

--- a/wsgidav/addons/mongo_property_manager.py
+++ b/wsgidav/addons/mongo_property_manager.py
@@ -40,7 +40,7 @@ DOT_ESCAPE = "^"
 
 def encodeMongoKey(s):
     """Return an encoded version of `s` that may be used as MongoDB key."""
-    assert not DOT_ESCAPE in s
+    assert DOT_ESCAPE not in s
     return s.replace(".", DOT_ESCAPE)
 
 
@@ -76,7 +76,7 @@ class MongoPropertyManager(object):
 
         self.collection = self.db["properties"]
         util.log("MongoPropertyManager connected %r" % self.collection)
-        _res = self.collection.ensure_index("_url")
+        self.collection.ensure_index("_url")
 
     def _disconnect(self):
         if self.conn:
@@ -101,7 +101,7 @@ class MongoPropertyManager(object):
         propNames = []
         if doc:
             for name in doc.keys():
-                if not name in HIDDEN_KEYS:
+                if name not in HIDDEN_KEYS:
                     propNames.append(decodeMongoKey(name))
         return propNames
 

--- a/wsgidav/addons/mysql_dav_provider.py
+++ b/wsgidav/addons/mysql_dav_provider.py
@@ -303,7 +303,8 @@ class MySQLBrowserProvider(DAVProvider):
         self._count_initConnection = 0
 
     def __repr__(self):
-        return "%s for db '%s' on '%s' (user: '%s')'" % (self.__class__.__name__, self._db, self._host, self._user)
+        return "%s for db '%s' on '%s' (user: '%s')'" % (
+            self.__class__.__name__, self._db, self._host, self._user)
 
     def _splitPath(self, path):
         """Return (tableName, primaryKey) tuple for a request path."""

--- a/wsgidav/addons/nt_domain_controller.py
+++ b/wsgidav/addons/nt_domain_controller.py
@@ -133,13 +133,13 @@ class NTDomainController(object):
             domain = userdata[0]
             username = userdata[1]
 
-        if self._presetdomain != None:
+        if self._presetdomain is not None:
             domain = self._presetdomain
 
         return (domain, username)
 
     def _getDomainControllerName(self, domain):
-        if self._presetserver != None:
+        if self._presetserver is not None:
             return self._presetserver
 
         try:
@@ -178,7 +178,8 @@ class NTDomainController(object):
 
         try:
             htoken = win32security.LogonUser(
-                username, domain, password, win32security.LOGON32_LOGON_NETWORK, win32security.LOGON32_PROVIDER_DEFAULT)
+                username, domain, password, win32security.LOGON32_LOGON_NETWORK,
+                win32security.LOGON32_PROVIDER_DEFAULT)
         except win32security.error as err:
             _logger.warning("LogonUser failed for user '%s': %s" % (username, err))
             return False

--- a/wsgidav/dav_error.py
+++ b/wsgidav/dav_error.py
@@ -7,9 +7,7 @@ Implements a DAVError class that is used to signal WebDAV and HTTP errors.
 """
 from __future__ import print_function
 
-import cgi
 import datetime
-import sys
 import traceback
 
 # Trick PyDev to do intellisense and don't produce warnings:
@@ -144,7 +142,7 @@ class DAVErrorCondition(object):
         assert href.startswith("/")
         assert self.conditionCode in (PRECONDITION_CODE_LockConflict,
                                       PRECONDITION_CODE_MissingLockToken)
-        if not href in self.hrefs:
+        if href not in self.hrefs:
             self.hrefs.append(href)
 
     def as_xml(self):
@@ -178,7 +176,9 @@ class DAVError(Exception):
                  statusCode,
                  contextinfo=None,
                  srcexception=None,
-                 errcondition=None):  # allow passing of Pre- and Postconditions, see http://www.webdav.org/specs/rfc4918.html#precondition.postcondition.xml.elements
+                 errcondition=None):
+        # allow passing of Pre- and Postconditions, see
+        # http://www.webdav.org/specs/rfc4918.html#precondition.postcondition.xml.elements
         self.value = int(statusCode)
         self.contextinfo = contextinfo
         self.srcexception = srcexception
@@ -224,7 +224,8 @@ class DAVError(Exception):
         status = getHttpStatusString(self)
         html = []
         html.append(
-            "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>")
+            "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' "
+            "'http://www.w3.org/TR/html4/strict.dtd'>")
         html.append("<html><head>")
         html.append(
             "  <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>")

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -116,8 +116,8 @@ _standardLivePropNames = ["{DAV:}creationdate",
 _lockPropertyNames = ["{DAV:}lockdiscovery",
                       "{DAV:}supportedlock"]
 
-#DAVHRES_Continue = "continue"
-#DAVHRES_Done = "done"
+# DAVHRES_Continue = "continue"
+# DAVHRES_Done = "done"
 
 # ========================================================================
 # _DAVResource
@@ -456,7 +456,7 @@ class _DAVResource(object):
         if depth != "0" and self.isCollection:
             for child in self.getMemberList():
                 if not child:
-                    _ = self.getMemberList()
+                    self.getMemberList()
                 want = (collections and child.isCollection) or (
                     resources and not child.isCollection)
                 if want and not depthFirst:
@@ -1240,7 +1240,8 @@ class DAVCollection(_DAVResource):
 #        return self.memberCache["members"]
 #
 #    def _cachePurge(self):
-#        self.memberCache["created"] = self.memberCache["lastUsed"] = self.memberCache["members"] = None
+#        self.memberCache["created"] = self.memberCache["lastUsed"] = None
+#        self.memberCache["members"] = None
 
 #    def getContentLanguage(self):
 #        return None
@@ -1406,13 +1407,13 @@ class DAVProvider(object):
         self.sharePath = sharePath
 
     def setLockManager(self, lockManager):
-        assert not lockManager or hasattr(
-            lockManager, "checkWritePermission"), "Must be compatible with wsgidav.lock_manager.LockManager"
+        assert not lockManager or hasattr(lockManager, "checkWritePermission"), ("Must be "
+            "compatible with wsgidav.lock_manager.LockManager")
         self.lockManager = lockManager
 
     def setPropManager(self, propManager):
-        assert not propManager or hasattr(
-            propManager, "copyProperties"), "Must be compatible with wsgidav.property_manager.PropertyManager"
+        assert not propManager or hasattr(propManager, "copyProperties"), ("Must be compatible "
+            "with wsgidav.property_manager.PropertyManager")
         self.propManager = propManager
 
     def refUrlToPath(self, refUrl):

--- a/wsgidav/dir_browser.py
+++ b/wsgidav/dir_browser.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 
 import os
 import sys
-import urllib
 
 from wsgidav import __version__, compat, util
 from wsgidav.dav_error import HTTP_MEDIATYPE_NOT_SUPPORTED, HTTP_OK, DAVError
@@ -194,7 +193,7 @@ class WsgiDavDirBrowser(BaseMiddleware):
         trailer = dirConfig.get("response_trailer")
         if trailer:
             trailer = trailer.replace("${version}",
-                                      "<a href='https://github.com/mar10/wsgidav/'>WsgiDAV/%s</a>" % __version__)
+                "<a href='https://github.com/mar10/wsgidav/'>WsgiDAV/%s</a>" % __version__)
             trailer = trailer.replace("${time}", util.getRfc1123Time())
         else:
             trailer = ("<a href='https://github.com/mar10/wsgidav/'>WsgiDAV/%s</a> - %s"
@@ -202,7 +201,8 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
         html = []
         html.append(
-            "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>")
+            "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' "
+            "'http://www.w3.org/TR/html4/strict.dtd'>")
         html.append("<html>")
         html.append("<head>")
         html.append(
@@ -221,7 +221,8 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
         if dirConfig.get("ms_sharepoint_plugin"):
             html.append(
-                "<object id='winFirefoxPlugin' type='application/x-sharepoint' width='0' height='0' style=''visibility: hidden;'></object>")
+                "<object id='winFirefoxPlugin' type='application/x-sharepoint' width='0' "
+                "height='0' style=''visibility: hidden;'></object>")
 
         html.append("</head>")
         html.append("<body onload='onLoad()'>")
@@ -231,11 +232,11 @@ class WsgiDavDirBrowser(BaseMiddleware):
         # Add DAV-Mount link and Web-Folder link
         links = []
         if dirConfig.get("davmount"):
-            links.append("<a title='Open this folder in a WebDAV client.' href='%s?davmount'>Mount</a>" %
-                         util.makeCompleteUrl(environ))
+            links.append("<a title='Open this folder in a WebDAV client.' "
+                "href='%s?davmount'>Mount</a>" % util.makeCompleteUrl(environ))
         if dirConfig.get("ms_mount"):
-            links.append("<a title='Open as Web Folder (requires Microsoft Internet Explorer)' href='' FOLDER='%s'>Open as Web Folder</a>" %
-                         util.makeCompleteUrl(environ))
+            links.append("<a title='Open as Web Folder (requires Microsoft Internet Explorer)' "
+                "href='' FOLDER='%s'>Open as Web Folder</a>" % util.makeCompleteUrl(environ))
 #                html.append("<a href='' FOLDER='%ssetup.py'>Open setup.py as WebDAV</a>" % util.makeCompleteUrl(environ))
         if links:
             html.append("<p>%s</p>" % " &#8211; ".join(links))
@@ -246,7 +247,8 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
         html.append("<thead>")
         html.append(
-            "<tr><th>Name</th> <th>Type</th> <th class='right'>Size</th> <th class='right'>Last modified</th> </tr>")
+            "<tr><th>Name</th> <th>Type</th> <th class='right'>Size</th> "
+            "<th class='right'>Last modified</th> </tr>")
         html.append("</thead>")
 
         html.append("<tbody>")

--- a/wsgidav/domain_controller.py
+++ b/wsgidav/domain_controller.py
@@ -72,13 +72,15 @@ class WsgiDAVDomainController(object):
         """Return True if this realm requires authentication or False if it is
         available for general access."""
         # TODO: Should check for --allow_anonymous?
-#        assert realmname in environ["wsgidav.config"]["user_mapping"], "Currently there must be at least on user mapping for this realm"
+#        assert realmname in environ["wsgidav.config"]["user_mapping"], (
+#            "Currently there must be at least on user mapping for this realm")
         return realmname in self.userMap
 
     def isRealmUser(self, realmname, username, environ):
         """Returns True if this username is valid for the realm, False otherwise."""
 #        if environ["wsgidav.verbose"] >= 2:
-#            print >>sys.stdout, "isRealmUser('%s', '%s'): %s" %(realmname, username, realmname in self.userMap and username in self.userMap[realmname])
+#            print >>sys.stdout, "isRealmUser('%s', '%s'): %s" %(realmname, username,
+#                realmname in self.userMap and username in self.userMap[realmname])
         return realmname in self.userMap and username in self.userMap[realmname]
 
     def getRealmUserPassword(self, realmname, username, environ):

--- a/wsgidav/error_printer.py
+++ b/wsgidav/error_printer.py
@@ -95,13 +95,14 @@ class ErrorPrinter(BaseMiddleware):
             status = getHttpStatusString(e)
             # Dump internal errors to console
             if e.value == HTTP_INTERNAL_ERROR:
-                print(
-                    "ErrorPrinter: caught HTTPRequestException(HTTP_INTERNAL_ERROR)", file=sys.stdout)
+                print("ErrorPrinter: caught HTTPRequestException("
+                    "HTTP_INTERNAL_ERROR)", file=sys.stdout)
                 traceback.print_exc(10, environ.get(
                     "wsgi.errors") or sys.stdout)
                 print("e.srcexception:\n%s" % e.srcexception, file=sys.stdout)
             elif e.value in (HTTP_NOT_MODIFIED, HTTP_NO_CONTENT):
-                #                util.log("ErrorPrinter: forcing empty error response for %s" % e.value)
+                # util.log("ErrorPrinter: forcing empty error response for %s"
+                #    % e.value)
                 # See paste.lint: these code don't have content
                 start_response(status, [("Content-Length", "0"),
                                         ("Date", util.getRfc1123Time()),

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -252,7 +252,7 @@ class FolderResource(DAVCollection):
 
         See DAVResource.createEmptyResource()
         """
-        assert not "/" in name
+        assert "/" not in name
         if self.provider.readonly:
             raise DAVError(HTTP_FORBIDDEN)
         path = util.joinUri(self.path, name)
@@ -266,7 +266,7 @@ class FolderResource(DAVCollection):
 
         See DAVResource.createCollection()
         """
-        assert not "/" in name
+        assert "/" not in name
         if self.provider.readonly:
             raise DAVError(HTTP_FORBIDDEN)
         path = util.joinUri(self.path, name)

--- a/wsgidav/http_authenticator.py
+++ b/wsgidav/http_authenticator.py
@@ -80,7 +80,6 @@ See `Developers info`_ for more information about the WsgiDAV architecture.
 """
 from __future__ import print_function
 
-import base64
 import random
 import re
 import time
@@ -165,13 +164,15 @@ class HTTPAuthenticator(BaseMiddleware):
         if self._domaincontroller.__class__.__name__ == wdcName:
             if self._authacceptdigest or self._authdefaultdigest or not self._authacceptbasic:
                 util.warn(
-                    "WARNING: %s requires basic authentication.\n\tSet acceptbasic=True, acceptdigest=False, defaultdigest=False" % wdcName)
+                    "WARNING: %s requires basic authentication.\n\tSet acceptbasic=True, "
+                    "acceptdigest=False, defaultdigest=False" % wdcName)
 
     def getDomainController(self):
         return self._domaincontroller
 
     def allowAnonymousAccess(self, share):
-        return isinstance(self._domaincontroller, WsgiDAVDomainController) and not self._user_mapping.get(share)
+        return (isinstance(self._domaincontroller, WsgiDAVDomainController)
+            and not self._user_mapping.get(share))
 
     def __call__(self, environ, start_response):
         realmname = self._domaincontroller.getDomainRealm(
@@ -195,8 +196,8 @@ class HTTPAuthenticator(BaseMiddleware):
 
         if self._trusted_auth_header and environ.get(self._trusted_auth_header):
             # accept a username that was injected by a trusted upstream server
-            _logger.debug("Accept trusted username %s='%s'for realm '%s'"
-                          % (self._trusted_auth_header, environ.get(self._trusted_auth_header), realmname))
+            _logger.debug("Accept trusted username %s='%s'for realm '%s'" % (
+                    self._trusted_auth_header, environ.get(self._trusted_auth_header), realmname))
             environ["http_authenticator.realm"] = realmname
             environ["http_authenticator.username"] = environ.get(
                 self._trusted_auth_header)
@@ -397,7 +398,8 @@ class HTTPAuthenticator(BaseMiddleware):
             req_method = environ["REQUEST_METHOD"]
 
             required_digest = self.computeDigestResponse(
-                req_username, realmname, req_password, req_method, req_uri, req_nonce, req_cnonce, req_qop, req_nc)
+                req_username, realmname, req_password, req_method, req_uri, req_nonce, req_cnonce,
+                req_qop, req_nc)
 
             if required_digest != req_response:
                 _logger.warning("computeDigestResponse('%s', '%s', ...): %s != %s" % (
@@ -405,10 +407,12 @@ class HTTPAuthenticator(BaseMiddleware):
                 if HOTFIX_WINXP_AcceptRootShareLogin:
                     # Hotfix: also accept '/' digest
                     root_digest = self.computeDigestResponse(
-                        req_username, "/", req_password, req_method, req_uri, req_nonce, req_cnonce, req_qop, req_nc)
+                        req_username, "/", req_password, req_method, req_uri, req_nonce,
+                        req_cnonce, req_qop, req_nc)
                     if root_digest == req_response:
                         _logger.warning(
-                            "authDigestAuthRequest: HOTFIX: accepting '/' login for '%s'." % realmname)
+                            "authDigestAuthRequest: HOTFIX: accepting '/' login for '%s'." %
+                            realmname)
                     else:
                         isinvalidreq = True
                 else:
@@ -426,7 +430,8 @@ class HTTPAuthenticator(BaseMiddleware):
         environ["http_authenticator.username"] = req_username
         return self._application(environ, start_response)
 
-    def computeDigestResponse(self, username, realm, password, method, uri, nonce, cnonce, qop, nc):
+    def computeDigestResponse(
+            self, username, realm, password, method, uri, nonce, cnonce, qop, nc):
         A1 = username + ":" + realm + ":" + password
         A2 = method + ":" + uri
         if qop:

--- a/wsgidav/lock_manager.py
+++ b/wsgidav/lock_manager.py
@@ -163,8 +163,10 @@ class LockManager(object):
             ownerDict.setdefault(lock["owner"], []).append(tok)
             urlDict.setdefault(lock["root"], []).append(tok)
 
-#            assert ("URL2TOKEN:" + v["root"]) in self._dict, "Inconsistency: missing URL2TOKEN:%s" % v["root"]
-#            assert v["token"] in self._dict["URL2TOKEN:" + v["root"]], "Inconsistency: missing token %s in URL2TOKEN:%s" % (v["token"], v["root"])
+#            assert ("URL2TOKEN:" + v["root"]) in self._dict, ("Inconsistency: missing"
+#                "URL2TOKEN:%s") % v["root"]
+#            assert v["token"] in self._dict["URL2TOKEN:" + v["root"]], ("Inconsistency: missing "
+#                "token %s in URL2TOKEN:%s" % (v["token"], v["root"])
 
         print("Locks:", file=out)
         pprint(tokenDict, indent=0, width=255)
@@ -227,7 +229,8 @@ class LockManager(object):
             # Raises DAVError on conflict:
             self._checkLockPermission(
                 url, locktype, lockscope, lockdepth, tokenList, principal)
-            return self._generateLock(principal, locktype, lockscope, lockdepth, lockowner, url, timeout)
+            return self._generateLock(
+                principal, locktype, lockscope, lockdepth, lockowner, url, timeout)
         finally:
             self._lock.release()
 
@@ -290,7 +293,8 @@ class LockManager(object):
                 if u != url and l["depth"] != "infinity":
                     continue  # We only consider parents with Depth: infinity
                 # TODO: handle shared locks in some way?
-#                if l["scope"] == "shared" and lockscope == "shared" and principal != l["principal"]:
+#                if (l["scope"] == "shared" and lockscope == "shared"
+#                   and principal != l["principal"]):
 # continue  # Only compatible with shared locks by other users
                 if principal is None or principal == l["principal"]:
                     lockList.append(l)

--- a/wsgidav/lock_storage.py
+++ b/wsgidav/lock_storage.py
@@ -34,7 +34,7 @@ __docformat__ = "reStructuredText"
 _logger = util.getModuleLogger(__name__)
 
 # TODO: comment's from Ian Bicking (2005)
-#@@: Use of shelve means this is only really useful in a threaded environment.
+# @@: Use of shelve means this is only really useful in a threaded environment.
 #    And if you have just a single-process threaded environment, you could get
 #    nearly the same effect with a dictionary of threading.Lock() objects.  Of course,
 #    it would be better to move off shelve anyway, probably to a system with
@@ -205,7 +205,7 @@ class LockStorageDict(object):
 
             # Store locked path reference
             key = "URL2TOKEN:%s" % path
-            if not key in self._dict:
+            if key not in self._dict:
                 self._dict[key] = [token]
             else:
                 # Note: Shelve dictionary returns copies, so we must reassign
@@ -265,7 +265,7 @@ class LockStorageDict(object):
             # Remove url to lock mapping
             key = "URL2TOKEN:%s" % lock.get("root")
             if key in self._dict:
-                #                _logger.debug("    delete token %s from url %s" % (token, lock.get("root")))
+                # _logger.debug("    delete token %s from url %s" % (token, lock.get("root")))
                 tokList = self._dict[key]
                 if len(tokList) > 1:
                     # Note: shelve dictionary returns copies, so we must
@@ -380,7 +380,7 @@ class LockStorageShelve(LockStorageDict):
         # careful to re-assign values to _dict after modifying them
         self._dict = shelve.open(self._storagePath, writeback=False)
 #        if __debug__ and self._verbose >= 2:
-##                self._check("After shelve.open()")
+#                self._check("After shelve.open()")
 #            self._dump("After shelve.open()")
 
     def close(self):

--- a/wsgidav/property_manager.py
+++ b/wsgidav/property_manager.py
@@ -30,7 +30,7 @@ from wsgidav import util
 from wsgidav.rw_lock import ReadWriteLock
 
 # TODO: comment's from Ian Bicking (2005)
-#@@: Use of shelve means this is only really useful in a threaded environment.
+# @@: Use of shelve means this is only really useful in a threaded environment.
 #    And if you have just a single-process threaded environment, you could get
 #    nearly the same effect with a dictionary of threading.Lock() objects.  Of course,
 #    it would be better to move off shelve anyway, probably to a system with
@@ -101,7 +101,7 @@ class PropertyManager(object):
 #                print "  -> %s" % self._dict[k]
 #            self._dump()
             for k, v in self._dict.items():
-                _ = "%s, %s" % (k, v)
+                "%s, %s" % (k, v)
 #            _logger.debug("%s checks ok %s" % (self.__class__.__name__, msg))
             return True
         except Exception:
@@ -168,7 +168,8 @@ class PropertyManager(object):
             self._lock.release()
 
     def writeProperty(self, normurl, propname, propertyvalue, dryRun=False):
-        #        self._log("writeProperty(%s, %s, dryRun=%s):\n\t%s" % (normurl, propname, dryRun, propertyvalue))
+        # self._log("writeProperty(%s, %s, dryRun=%s):\n\t%s" % (normurl,
+        #   propname, dryRun, propertyvalue))
         assert normurl and normurl.startswith("/")
         assert propname  # and propname.startswith("{")
         assert propertyvalue is not None

--- a/wsgidav/request_resolver.py
+++ b/wsgidav/request_resolver.py
@@ -105,7 +105,7 @@ __docformat__ = "reStructuredText"
 # I leave them here after my refactoring for reference.
 #
 # Remarks:
-#@@: If this were just generalized URL mapping, you'd map it like:
+# @@: If this were just generalized URL mapping, you'd map it like:
 #    Incoming:
 #        SCRIPT_NAME=<approot>; PATH_INFO=/pubshare/PyFileServer/LICENSE
 #    After transforamtion:

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -11,8 +11,6 @@ See `Developers info`_ for more information about the WsgiDAV architecture.
 """
 from __future__ import print_function
 
-import urllib
-
 from wsgidav import compat, util, xml_tools
 from wsgidav.dav_error import (
     HTTP_BAD_GATEWAY,
@@ -78,9 +76,10 @@ class RequestServer(object):
 
     def __call__(self, environ, start_response):
         assert "wsgidav.verbose" in environ
-        # TODO: allow anonymous somehow: this should run, even if http_authenticator middleware is not installed
+        # TODO: allow anonymous somehow: this should run, even if http_authenticator middleware
+        # is not installed
 #        assert "http_authenticator.username" in environ
-        if not "http_authenticator.username" in environ:
+        if "http_authenticator.username" not in environ:
             _logger.info(
                 "*** missing 'http_authenticator.username' in environ")
 
@@ -228,7 +227,7 @@ class RequestServer(object):
             util.evaluateHTTPConditionals(
                 res, lastmodified, entitytag, environ)
 
-        if not "HTTP_IF" in environ:
+        if "HTTP_IF" not in environ:
             return
 
         # Raise HTTP_PRECONDITION_FAILED, if DAV 'If' condition fails
@@ -301,7 +300,8 @@ class RequestServer(object):
             # TODO: implement <include> option
 #            elif pfnode.tag == "{DAV:}include":
 #                if not propFindMode in (None, "allprop"):
-#                    self._fail(HTTP_BAD_REQUEST, "<include> element is only valid with 'allprop'.")
+#                    self._fail(HTTP_BAD_REQUEST,
+#                        "<include> element is only valid with 'allprop'.")
 #                for pfpnode in pfnode:
 #                    propNameList.append(pfpnode.tag)
             elif pfnode.tag == "{DAV:}propname":
@@ -672,7 +672,7 @@ class RequestServer(object):
                 contentlength = 0
             else:
                 self._fail(HTTP_LENGTH_REQUIRED,
-                           "PUT request with invalid Content-Length: (%s)" % environ.get("CONTENT_LENGTH"))
+                   "PUT request with invalid Content-Length: (%s)" % environ.get("CONTENT_LENGTH"))
 
         hasErrors = False
         try:
@@ -732,7 +732,8 @@ class RequestServer(object):
 #                # by reading until the end of the stream. This may block however!
 #                # The iterator produced small chunks of varying size, but not
 #                # sure, if we always get everything before it times out.
-#                _logger.warning("PUT with invalid Content-Length (%s). Trying to read all (this may timeout)..." % environ.get("CONTENT_LENGTH"))
+#                _logger.warning("PUT with invalid Content-Length (%s). Trying to read all "
+#                    "(this may timeout)..." % environ.get("CONTENT_LENGTH"))
 #                nb = 0
 #                try:
 #                    for s in environ["wsgi.input"]:
@@ -750,7 +751,8 @@ class RequestServer(object):
                     n = min(contentremain, self.block_size)
                     readbuffer = environ["wsgi.input"].read(n)
                     # This happens with litmus expect-100 test:
-#                    assert len(readbuffer) > 0, "input.read(%s) returned %s bytes" % (n, len(readbuffer))
+#                    assert len(readbuffer) > 0, "input.read(%s) returned %s bytes" % (
+#                        n, len(readbuffer))
                     if not len(readbuffer) > 0:
                         util.warn("input.read(%s) returned 0 bytes" % n)
                         break
@@ -960,7 +962,7 @@ class RequestServer(object):
                         "check unmatched dest before copy: %s" % dRes)
                     relUrl = dRes.path[destRootLen:]
                     sp = srcPath + relUrl
-                    if not sp in srcPathList:
+                    if sp not in srcPathList:
                         _logger.debug(
                             "Remove unmatched dest before copy: %s" % dRes)
                         dRes.delete()
@@ -1246,13 +1248,15 @@ class RequestServer(object):
 #        for nu, e in dictStatus.items():
 #            responseEL = etree.SubElement(multistatusEL, "{DAV:}response")
 #            etree.SubElement(responseEL, "{DAV:}href").text = nu
-#            etree.SubElement(responseEL, "{DAV:}status").text = "HTTP/1.1 %s" % getHttpStatusString(e)
+#            etree.SubElement(responseEL, "{DAV:}status").text = "HTTP/1.1 %s" %
+#                getHttpStatusString(e)
 #            # TODO: all responses should have this(?):
 #            if e.contextinfo:
 #                etree.SubElement(multistatusEL, "{DAV:}responsedescription").text = e.contextinfo
 #
 # if responsedescription:
-##            etree.SubElement(multistatusEL, "{DAV:}responsedescription").text = "\n".join(responsedescription)
+#            etree.SubElement(multistatusEL, "{DAV:}responsedescription").text = "\n".join(
+#                responsedescription)
 #
 # return util.sendMultiStatusResponse(environ, start_response,
 # multistatusEL)
@@ -1272,7 +1276,7 @@ class RequestServer(object):
         elif util.getContentLength(environ) != 0:
             self._fail(HTTP_MEDIATYPE_NOT_SUPPORTED,
                        "The server does not handle any body content.")
-        elif not "HTTP_LOCK_TOKEN" in environ:
+        elif "HTTP_LOCK_TOKEN" not in environ:
             self._fail(HTTP_BAD_REQUEST, "Missing lock token.")
 
         self._evaluateIfHeaders(res, environ)
@@ -1399,7 +1403,8 @@ class RequestServer(object):
             self._fail(HTTP_NOT_FOUND)
         elif res.isCollection:
             self._fail(HTTP_FORBIDDEN,
-                       "Directory browsing not enabled (WsgiDavDirBrowser middleware may be enabled using the dir_browser option).")
+               ("Directory browsing not enabled (WsgiDavDirBrowser middleware may be enabled using"
+                " the dir_browser option)."))
 
         self._evaluateIfHeaders(res, environ)
 
@@ -1468,7 +1473,8 @@ class RequestServer(object):
         res.finalizeHeaders(environ, responseHeaders)
 
         if ispartialranges:
-            #            responseHeaders.append(("Content-Ranges", "bytes " + str(rangestart) + "-" + str(rangeend) + "/" + str(rangelength)))
+            # responseHeaders.append(("Content-Ranges", "bytes " + str(rangestart) + "-" +
+            #    str(rangeend) + "/" + str(rangelength)))
             responseHeaders.append(
                 ("Content-Range", "bytes %s-%s/%s" % (rangestart, rangeend, filesize)))
             start_response("206 Partial Content", responseHeaders)

--- a/wsgidav/samples/dav_provider_tools.py
+++ b/wsgidav/samples/dav_provider_tools.py
@@ -48,7 +48,7 @@ class VirtualCollection(DAVCollection):
         return True
 
     def getMember(self, name):
-#        raise NotImplementedError()
+        # raise NotImplementedError()
         return self.provider.getResourceInst(util.joinUri(self.path, name),
                                              self.environ)
 
@@ -171,10 +171,10 @@ class FileResource(_VirtualNonCollection):
 #        return compat.quote(self.provider.sharePath + refPath)
 
     def getContent(self):
-#        mime = self.getContentType()
+        # mime = self.getContentType()
         # GC issue 57: always store as binary
-#        if mime.startswith("text"):
-#            return open(self.filePath, "r", FileResource.BUFFER_SIZE)
+        # if mime.startswith("text"):
+        #     return open(self.filePath, "r", FileResource.BUFFER_SIZE)
         return open(self.filePath, "rb", FileResource.BUFFER_SIZE)
 
 

--- a/wsgidav/samples/virtual_dav_provider.py
+++ b/wsgidav/samples/virtual_dav_provider.py
@@ -220,7 +220,7 @@ class CategoryTypeCollection(DAVCollection):
                     names.append(data["orga"])
             elif self.name == "by_tag":
                 for tag in data["tags"]:
-                    if not tag in names:
+                    if tag not in names:
                         names.append(tag)
 
         names.sort()
@@ -266,7 +266,7 @@ class VirtualResource(DAVCollection):
     _artifactNames = (".Info.txt",
                       ".Info.html",
                       ".Description.txt",
-#                     ".Admin.html",
+                      # ".Admin.html",
                       )
     _supportedProps = ["{virtres:}key",
                        "{virtres:}title",
@@ -302,7 +302,7 @@ class VirtualResource(DAVCollection):
     def handleDelete(self):
         """Change semantic of DELETE to remove resource tags."""
         # DELETE is only supported for the '/by_tag/' collection
-        if not "/by_tag/" in self.path:
+        if "/by_tag/" not in self.path:
             raise DAVError(HTTP_FORBIDDEN)
         # path must be '/by_tag/<tag>/<resname>'
         catType, tag, _rest = util.saveSplit(self.path.strip("/"), "/", 2)
@@ -314,20 +314,20 @@ class VirtualResource(DAVCollection):
     def handleCopy(self, destPath, depthInfinity):
         """Change semantic of COPY to add resource tags."""
         # destPath must be '/by_tag/<tag>/<resname>'
-        if not "/by_tag/" in destPath:
+        if "/by_tag/" not in destPath:
             raise DAVError(HTTP_FORBIDDEN)
         catType, tag, _rest = util.saveSplit(destPath.strip("/"), "/", 2)
         assert catType == "by_tag"
-        if not tag in self.data["tags"]:
+        if tag not in self.data["tags"]:
             self.data["tags"].append(tag)
         return True  # OK
 
     def handleMove(self, destPath):
         """Change semantic of MOVE to change resource tags."""
         # path and destPath must be '/by_tag/<tag>/<resname>'
-        if not "/by_tag/" in self.path:
+        if "/by_tag/" not in self.path:
             raise DAVError(HTTP_FORBIDDEN)
-        if not "/by_tag/" in destPath:
+        if "/by_tag/" not in destPath:
             raise DAVError(HTTP_FORBIDDEN)
         catType, tag, _rest = util.saveSplit(self.path.strip("/"), "/", 2)
         assert catType == "by_tag"
@@ -335,7 +335,7 @@ class VirtualResource(DAVCollection):
         self.data["tags"].remove(tag)
         catType, tag, _rest = util.saveSplit(destPath.strip("/"), "/", 2)
         assert catType == "by_tag"
-        if not tag in self.data["tags"]:
+        if tag not in self.data["tags"]:
             self.data["tags"].append(tag)
         return True  # OK
 
@@ -564,10 +564,10 @@ class VirtualResFile(_VirtualNonCollection):
         return compat.quote(self.provider.sharePath + refPath)
 
     def getContent(self):
-#        mime = self.getContentType()
+        # mime = self.getContentType()
         # GC issue 57: always store as binary
-#        if mime.startswith("text"):
-#            return open(self.filePath, "r", BUFFER_SIZE)
+        # if mime.startswith("text"):
+        #     return open(self.filePath, "r", BUFFER_SIZE)
         return open(self.filePath, "rb", BUFFER_SIZE)
 
 
@@ -605,7 +605,7 @@ class VirtualResourceProvider(DAVProvider):
 #    def __init__(self):
 #        super(VirtualResourceProvider, self).__init__()
 #        self.resourceData = _resourceData
-##        self.rootCollection = VirtualCollection(self, "/", environ)
+#        self.rootCollection = VirtualCollection(self, "/", environ)
 #
 #
 #    def getResourceInst(self, path, environ):
@@ -622,7 +622,8 @@ class VirtualResourceProvider(DAVProvider):
 #
 #        catType, cat, resName, artifactName = util.saveSplit(path.strip("/"), "/", 3)
 #
-#        _logger.info("getResourceInst('%s'): catType=%s, cat=%s, resName=%s" % (path, catType, cat, resName))
+#        _logger.info("getResourceInst('%s'): catType=%s, cat=%s, resName=%s" % (path, catType,
+#             cat, resName))
 #
 #        if catType and catType not in _alllowedCategories:
 #            return None

--- a/wsgidav/server/ext_wsgiutils_server.py
+++ b/wsgidav/server/ext_wsgiutils_server.py
@@ -8,7 +8,8 @@ It supports passing all of the HTTP and WebDAV (rfc 2518) methods.
 It includes code from the following sources:
 ``wsgiServer.py`` from wsgiKit <http://www.owlfish.com/software/wsgiutils/> under PSF license,
 ``wsgiutils_server.py`` from Paste <http://pythonpaste.org> under PSF license,
-flexible handler method <http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/307618> under public domain.
+flexible handler method <http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/307618>
+under public domain.
 
 
 Running as standalone server
@@ -46,10 +47,10 @@ where ``publish_app`` is the WSGI application to be run, it will be called with
 ``publish_app(environ, start_response)`` for each incoming request, as described in
 WSGI <http://www.python.org/peps/pep-0333.html>
 
-Note: if you are using the paster development server (from Paste <http://pythonpaste.org>), you can
-copy ``ext_wsgi_server.py`` to ``<Paste-installation>/paste/servers`` and use this server to run the
-application by specifying ``server='ext_wsgiutils'`` in the ``server.conf`` or appropriate paste
-configuration.
+Note: if you are using the paster development server (from Paste <http://pythonpaste.org>), you
+can copy ``ext_wsgi_server.py`` to ``<Paste-installation>/paste/servers`` and use this server to
+run the application by specifying ``server='ext_wsgiutils'`` in the ``server.conf`` or appropriate
+paste configuration.
 """
 from __future__ import print_function
 
@@ -125,8 +126,8 @@ class ExtHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def getApp(self):
         # We want fragments to be returned as part of <path>
-        _protocol, _host, path, _parameters, query, _fragment = compat.urlparse("http://dummyhost%s" % self.path,
-                                                                                allow_fragments=False)
+        _protocol, _host, path, _parameters, query, _fragment = compat.urlparse(
+            "http://dummyhost%s" % self.path, allow_fragments=False)
         # Find any application we might have
         for appPath, app in self.server.wsgiApplications:
             if (path.startswith(appPath)):
@@ -165,7 +166,8 @@ class ExtHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         return
 
     def runWSGIApp(self, application, scriptName, pathInfo, query):
-        # logging.info ("Running application with SCRIPT_NAME %s PATH_INFO %s" % (scriptName, pathInfo))
+        # logging.info ("Running application with SCRIPT_NAME %s PATH_INFO %s" % (
+        #     scriptName, pathInfo))
 
         if self.command == "PUT":
             pass  # breakpoint
@@ -304,7 +306,7 @@ class ExtServer (socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServer):
         self.stop_request = True
         time.sleep(.1)
         if self.stopped:
-#            print "stop_serve_forever() 'stopped'."
+            # print "stop_serve_forever() 'stopped'."
             return
 
         # Add a do_SHUTDOWN method to to the ExtHandler class

--- a/wsgidav/server/run_reloading_server.py
+++ b/wsgidav/server/run_reloading_server.py
@@ -13,7 +13,7 @@ from subprocess import Popen
 
 def run():
     args = sys.argv[1:]
-    if not "--reload" in args:
+    if "--reload" not in args:
         args.append("--reload")
 
     print("run_reloading_server", args)
@@ -22,10 +22,11 @@ def run():
         serverpath = os.path.join(os.path.dirname(__file__), "run_server.py")
         while True:
             p = Popen(["python", serverpath] + args,
-#                      stdin=sys.stdin,
-#                      stdout=subprocess.PIPE,
-#                      stderr=subprocess.PIPE,
-    #                  preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags
+                      # stdin=sys.stdin,
+                      # stdout=subprocess.PIPE,
+                      # stderr=subprocess.PIPE,
+                      # preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo,
+                      # creationflags
                       )
             sys.stdout = p.stdout
             sys.stderr = p.stderr

--- a/wsgidav/server/run_server.py
+++ b/wsgidav/server/run_server.py
@@ -107,7 +107,9 @@ See https://github.com/mar10/wsgidav for additional information.
     parser.add_argument("-H", "--host",  # '-h' conflicts with --help
                         dest="host",
                         # default="localhost",
-                        help="host to serve from (default: localhost). 'localhost' is only accessible from the local computer. Use 0.0.0.0 to make your application public"),
+                        help=("host to serve from (default: localhost). 'localhost' is only "
+                            "accessible from the local computer. Use 0.0.0.0 to make your "
+                            "application public")),
     parser.add_argument("-r", "--root",
                         dest="root_path",
                         help="path to a file system folder to publish as share '/'.")
@@ -126,7 +128,8 @@ See https://github.com/mar10/wsgidav for additional information.
 
     parser.add_argument("-c", "--config",
                         dest="config_file",
-                        help="configuration file (default: %s in current directory)" % DEFAULT_CONFIG_FILE)
+                        help=("configuration file (default: %s in current directory)" %
+                            DEFAULT_CONFIG_FILE))
     parser.add_argument("--no-config",
                         action="store_true", dest="no_config",
                         help="do not try to load default %s" % DEFAULT_CONFIG_FILE)
@@ -135,7 +138,8 @@ See https://github.com/mar10/wsgidav for additional information.
 
 #    parser.add_argument("--reload",
 #                        action="store_true", dest="reload",
-#                        help="restart server when source files are changed. Used by run_reloading_server (requires paste.reloader)")
+#                        help=("restart server when source files are changed. Used by "
+#                            "run_reloading_server (requires paste.reloader)"))
 
 #    parser.add_argument("", "--profile",
 #                      action="store_true", dest="profile",
@@ -200,13 +204,14 @@ def _readConfigFile(config_file, verbose):
                 continue
             conf[k] = v
     except Exception as e:
-#        if verbose >= 1:
-#            traceback.print_exc()
-        exceptioninfo = traceback.format_exception_only(sys.exc_type, sys.exc_value) #@UndefinedVariable
+        # if verbose >= 1:
+        #    traceback.print_exc()
+        exceptioninfo = traceback.format_exception_only(sys.exc_type, sys.exc_value)
         exceptiontext = ""
         for einfo in exceptioninfo:
             exceptiontext += einfo + "\n"
-#        raise RuntimeError("Failed to read configuration file: " + config_file + "\nDue to " + exceptiontext)
+#        raise RuntimeError("Failed to read configuration file: " + config_file + "\nDue to "
+#            + exceptiontext)
         print("Failed to read configuration file: " + config_file +
               "\nDue to " + exceptiontext, file=sys.stderr)
         raise
@@ -259,14 +264,16 @@ def _initConfig():
         pprint(config)
 
     # if not useLxml and config["verbose"] >= 1:
-    #     print("WARNING: Could not import lxml: using xml instead (slower). Consider installing lxml from http://codespeak.net/lxml/.")
+    #     print("WARNING: Could not import lxml: using xml instead (slower). Consider installing"
+    #         "lxml from http://codespeak.net/lxml/.")
 
     # print "verbose #3: ", config.get("verbose")
 
     if not config["provider_mapping"]:
         print("ERROR: No DAV provider defined. Try --help option.", file=sys.stderr)
         sys.exit(-1)
-#        raise RuntimeWarning("At least one DAV provider must be specified by a --root option, or in a configuration file.")
+#        raise RuntimeWarning("At least one DAV provider must be specified by a --root option,"
+#             or in a configuration file.")
 
     if cmdLineOpts.get("reload"):
         print("Installing paste.reloader.", file=sys.stderr)

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -22,7 +22,6 @@ import socket
 import stat
 import sys
 import time
-import urllib
 from email.utils import formatdate, parsedate
 from hashlib import md5
 from pprint import pformat
@@ -239,7 +238,8 @@ def getModuleLogger(moduleName, defaultToVerbose=False):
 #    _logger.debug("getModuleLogger(%s)" % moduleName)
     if not moduleName.startswith(BASE_LOGGER_NAME + "."):
         moduleName = BASE_LOGGER_NAME + "." + moduleName
-#    assert not "." in moduleName, "Only pass the module name, without leading '%s.'." % BASE_LOGGER_NAME
+#    assert not "." in moduleName, ("Only pass the module name, without "
+#        "leading '%s.'.") % BASE_LOGGER_NAME
 #    logger = logging.getLogger("%s.%s" % (BASE_LOGGER_NAME, moduleName))
     logger = logging.getLogger(moduleName)
     if logger.level == logging.NOTSET and not defaultToVerbose:
@@ -403,7 +403,7 @@ def stringRepr(s):
 
 
 def getFileExtension(path):
-    ext = os.path.splitext(url)[1]
+    ext = os.path.splitext(path)[1]
     return ext
 
 
@@ -510,8 +510,8 @@ def readAndDiscardInput(environ):
             else:
                 n = 1
             body = wsgi_input.read(n)
-            debug("Reading %s bytes from potentially unread httpserver.LimitedLengthFile: '%s'..." % (
-                n, body[:50]))
+            debug("Reading %s bytes from potentially unread httpserver.LimitedLengthFile: '%s'..."
+                % (n, body[:50]))
 
     elif hasattr(wsgi_input, "_sock") and hasattr(wsgi_input._sock, "settimeout"):
         # Seems to be a socket
@@ -615,7 +615,8 @@ def isEqualOrChildUri(parentUri, childUri):
     Similar to <util.isChildUri>_ ,  but this method also returns True, if parent
     equals child. ('/a/b' is considered identical with '/a/b/').
     """
-    return parentUri and childUri and (childUri.rstrip("/") + "/").startswith(parentUri.rstrip("/") + "/")
+    return (parentUri and childUri
+        and (childUri.rstrip("/") + "/").startswith(parentUri.rstrip("/") + "/"))
 
 
 def makeCompleteUrl(environ, localUri=None):
@@ -726,7 +727,7 @@ def parseXmlBody(environ, allowEmpty=False):
     # If dumps of the body are desired, then this is the place to do it pretty:
     if environ.get("wsgidav.dump_request_body"):
         write("%s XML request body:\n%s" % (environ["REQUEST_METHOD"],
-                                            compat.to_native(xmlToBytes(rootEL, pretty_print=True))))
+            compat.to_native(xmlToBytes(rootEL, pretty_print=True))))
         environ["wsgidav.dump_request_body"] = False
 
     return rootEL
@@ -778,7 +779,7 @@ def sendMultiStatusResponse(environ, start_response, multistatusEL):
     # pretty:
     if environ.get("wsgidav.dump_response_body"):
         xml = "%s XML response body:\n%s" % (environ["REQUEST_METHOD"],
-                                             compat.to_native(xmlToBytes(multistatusEL, pretty_print=True)))
+            compat.to_native(xmlToBytes(multistatusEL, pretty_print=True)))
         environ["wsgidav.dump_response_body"] = xml
 
     # Hotfix for Windows XP
@@ -832,7 +833,7 @@ def addPropertyResponse(multistatusEL, href, propList):
         # Collect namespaces, so we can declare them in the <response> for
         # compacter output
         ns, _ = splitNamespace(name)
-        if ns != "DAV:" and not ns in nsDict and ns != "":
+        if ns != "DAV:" and ns not in nsDict and ns != "":
             nsDict[ns] = True
             nsMap["NS%s" % nsCount] = ns
             nsCount += 1
@@ -845,7 +846,8 @@ def addPropertyResponse(multistatusEL, href, propList):
 #    log("href value:%s" % (stringRepr(href)))
 #    etree.SubElement(responseEL, "{DAV:}href").text = toUnicode(href)
     etree.SubElement(responseEL, "{DAV:}href").text = href
-#    etree.SubElement(responseEL, "{DAV:}href").text = compat.quote(href, safe="/" + "!*'()," + "$-_|.")
+#    etree.SubElement(responseEL, "{DAV:}href").text = compat.quote(href, safe="/" + "!*'(),"
+#       + "$-_|.")
 
     # One <propstat> per status code
     for status in propDict:
@@ -909,10 +911,12 @@ def getETag(filePath):
 
     if sys.platform == "win32":
         statresults = os.stat(unicodeFilePath)
-        return md5(filePath).hexdigest() + "-" + str(statresults[stat.ST_MTIME]) + "-" + str(statresults[stat.ST_SIZE])
+        return (md5(filePath).hexdigest() + "-" + str(statresults[stat.ST_MTIME]) + "-"
+            + str(statresults[stat.ST_SIZE]))
     else:
         statresults = os.stat(unicodeFilePath)
-        return str(statresults[stat.ST_INO]) + "-" + str(statresults[stat.ST_MTIME]) + "-" + str(statresults[stat.ST_SIZE])
+        return (str(statresults[stat.ST_INO]) + "-" + str(statresults[stat.ST_MTIME]) + "-"
+            + str(statresults[stat.ST_SIZE]))
 
 
 # ========================================================================
@@ -1043,11 +1047,11 @@ def evaluateHTTPConditionals(davres, lastmodified, entitytag, environ):
         return
     # Conditions
 
-    # An HTTP/1.1 origin server, upon receiving a conditional request that includes both a Last-Modified date
-    # (e.g., in an If-Modified-Since or If-Unmodified-Since header field) and one or more entity tags (e.g.,
-    # in an If-Match, If-None-Match, or If-Range header field) as cache validators, MUST NOT return a response
-    # status of 304 (Not Modified) unless doing so is consistent with all of the conditional header fields in
-    # the request.
+    # An HTTP/1.1 origin server, upon receiving a conditional request that includes both a
+    # Last-Modified date (e.g., in an If-Modified-Since or If-Unmodified-Since header field) and
+    # one or more entity tags (e.g., in an If-Match, If-None-Match, or If-Range header field) as
+    # cache validators, MUST NOT return a response status of 304 (Not Modified) unless doing so
+    # is consistent with all of the conditional header fields in the request.
 
     if "HTTP_IF_MATCH" in environ and davres.supportEtag():
         ifmatchlist = environ["HTTP_IF_MATCH"].split(",")
@@ -1067,9 +1071,9 @@ def evaluateHTTPConditionals(davres, lastmodified, entitytag, environ):
 
     # If-None-Match
     # If none of the entity tags match, then the server MAY perform the requested method as if the
-    # If-None-Match header field did not exist, but MUST also ignore any If-Modified-Since header field
-    # (s) in the request. That is, if no entity tags match, then the server MUST NOT return a 304 (Not Modified)
-    # response.
+    # If-None-Match header field did not exist, but MUST also ignore any If-Modified-Since header
+    # field (s) in the request. That is, if no entity tags match, then the server MUST NOT return
+    # a 304 (Not Modified) response.
     ignoreIfModifiedSince = False
     if "HTTP_IF_NONE_MATCH" in environ and davres.supportEtag():
         ifmatchlist = environ["HTTP_IF_NONE_MATCH"].split(",")
@@ -1112,7 +1116,7 @@ def parseIfHeaderDict(environ):
     if "wsgidav.conditions.if" in environ:
         return
 
-    if not "HTTP_IF" in environ:
+    if "HTTP_IF" not in environ:
         environ["wsgidav.conditions.if"] = None
         environ["wsgidav.ifLockTokenList"] = []
         return

--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -47,7 +47,6 @@ from __future__ import print_function
 import sys
 import threading
 import time
-import urllib
 
 from wsgidav import compat, util
 from wsgidav.dav_provider import DAVProvider
@@ -125,7 +124,7 @@ def _checkConfig(config):
     mandatoryFields = ["provider_mapping",
                        ]
     for field in mandatoryFields:
-        if not field in config:
+        if field not in config:
             raise ValueError(
                 "Invalid configuration: missing required field '%s'" % field)
 
@@ -240,7 +239,8 @@ class WsgiDAVApp(object):
 
     def __call__(self, environ, start_response):
 
-        #        util.log("SCRIPT_NAME='%s', PATH_INFO='%s'" % (environ.get("SCRIPT_NAME"), environ.get("PATH_INFO")))
+        # util.log("SCRIPT_NAME='%s', PATH_INFO='%s'" % (
+        #    environ.get("SCRIPT_NAME"), environ.get("PATH_INFO")))
 
         # We optionall unquote PATH_INFO here, although this should already be
         # done by the server (#8).
@@ -332,7 +332,8 @@ class WsgiDAVApp(object):
                 # A typical case: a GET request on a virtual resource, for which
                 # the provider doesn't know the length
                 util.warn(
-                    "Missing required Content-Length header in %s-response: closing connection" % statusCode)
+                    "Missing required Content-Length header in %s-response: closing connection" %
+                    statusCode)
                 forceCloseConnection = True
             elif not type(currentContentLength) is str:
                 util.warn("Invalid Content-Length header in response (%r): closing connection" %
@@ -405,7 +406,7 @@ class WsgiDAVApp(object):
                     environ.get("PATH_INFO", ""),
                     extra,
                     status,
-                    #                                        response_headers.get(""), # response Content-Length
+                    # response_headers.get(""), # response Content-Length
                     # referer
                 ), file=sys.stdout)
 

--- a/wsgidav/xml_tools.py
+++ b/wsgidav/xml_tools.py
@@ -53,11 +53,14 @@ def stringToXML(text):
         # TODO:
         # ExpatError: reference to invalid character number: line 1, column 62
         # litmus fails, when xml is used instead of lxml
-        # 18. propget............... FAIL (PROPFIND on `/temp/litmus/prop2': Could not read status line: connection was closed by server)
-        # text = <ns0:high-unicode xmlns:ns0="http://example.com/neon/litmus/">&#55296;&#56320;</ns0:high-unicode>
+        # 18. propget............... FAIL (PROPFIND on `/temp/litmus/prop2':
+        #   Could not read status line: connection was closed by server)
+        # text = <ns0:high-unicode xmlns:ns0="http://example.com/neon/litmus/">&#55296;&#56320;
+        #   </ns0:high-unicode>
         #        t2 = text.encode("utf8")
         #        return etree.XML(t2)
-        print("Error parsing XML string. If lxml is not available, and unicode is involved, then installing lxml _may_ solve this issue.", file=sys.stderr)
+        print("Error parsing XML string. If lxml is not available, and unicode is involved, then "
+            "installing lxml _may_ solve this issue.", file=sys.stderr)
         print("XML source:", text, file=sys.stderr)
         raise
 


### PR DESCRIPTION
This is the result after some manual fixes: 

22    E128 continuation line under-indented for visual indent
13    E501 line too long (153 > 99 characters)
2     E713 test for membership should be 'not in'
1     F401 'wsgidav._version.__version__' imported but unused
4     F811 redefinition of unused 'etree' from line 15
2     F821 undefined name 'unicode'
44

I think all the ones are missing there are excepts or comment code. So I will prefer you to review them manually. 
