### PR TITLE
Add hook for custom request handler

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -121,7 +121,7 @@ class RequestServer(object):
                 res.close()
             return
 
-        app_iter = method(environ, start_response)
+        app_iter = self._davProvider.customRequestHandler(environ, start_response, method)
         for v in app_iter:
             yield v
         if hasattr(app_iter, "close"):


### PR DESCRIPTION
Add the hook that makes the custom request handler work (on `custom_reqhandlers` branch). I understand that this was the intention [here](https://github.com/mar10/wsgidav/issues/55#issuecomment-256482554).