### PR TITLE
Capture all errors and log them

### DIFF
--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -47,6 +47,7 @@ from __future__ import print_function
 import sys
 import threading
 import time
+import traceback
 
 from wsgidav import compat, util
 from wsgidav.dav_provider import DAVProvider
@@ -412,10 +413,18 @@ class WsgiDAVApp(object):
 
             return start_response(status, response_headers, exc_info)
 
-        # Call next middleware
-        app_iter = self._application(environ, _start_response_wrapper)
-        for v in app_iter:
-            yield v
+        try:
+            # Call next middleware
+            app_iter = self._application(environ, _start_response_wrapper)
+            for v in app_iter:
+                yield v
+        except Exception as e:
+            output_destination = environ.get("wsgi.errors") or sys.stderr
+            print('-'*40, file=output_destination)
+            traceback.print_exc(10, output_destination)
+            print('-'*40, file=output_destination)
+            raise e
+
         if hasattr(app_iter, "close"):
             app_iter.close()
 


### PR DESCRIPTION
Currently many errors fail with a very hard to debug message that goes something like this:

``` bash
Traceback (most recent call last):
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 86, in run
    self.finish_response()
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 131, in finish_response
    self.close()
  File "/usr/lib/python2.7/wsgiref/simple_server.py", line 33, in close
    self.status.split(' ',1)[0], self.bytes_sent
AttributeError: 'NoneType' object has no attribute 'split'
```

This happens because the wsgiref server swallows the exceptions, so we need to intercept them and log it ourselves.
