### PR TITLE
Allow POST implementations

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -65,7 +65,7 @@ class RequestServer(object):
         #     self._possible_methods.extend( [ "PROPFIND" ] )
         if not self._davProvider.isReadOnly():
             self._possible_methods.extend(
-                ["PUT", "DELETE", "COPY", "MOVE", "MKCOL", "PROPPATCH"])
+                ["PUT", "DELETE", "COPY", "MOVE", "MKCOL", "PROPPATCH", "POST"])
             # if self._davProvider.propManager is not None:
             #     self._possible_methods.extend( [ "PROPPATCH" ] )
             if self._davProvider.lockManager is not None:


### PR DESCRIPTION
Now that we allow method overrides, we still have to add POST to the list of possible methods so that it can be used. (Currently `doPOST()` never gets called).