### PR TITLE
PROPPATCH atomicity with removeProperty

### DIFF
--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -758,7 +758,7 @@ class _DAVResource(object):
         if pm and not propname.startswith("{DAV:}"):
             refUrl = self.getRefUrl()
             if value is None:
-                return pm.removeProperty(refUrl, propname)
+                return pm.removeProperty(refUrl, propname, dryRun)
             else:
                 value = etree.tostring(value)
                 return pm.writeProperty(refUrl, propname, value, dryRun)


### PR DESCRIPTION
Fixes removeProperty call to not lose dryRun, otherwise removeProperty is called twice for real