### PR TITLE
Prevent error when missing environment variable.

### DIFF
--- a/wsgidav/debug_filter.py
+++ b/wsgidav/debug_filter.py
@@ -99,13 +99,12 @@ class WsgiDavDebugFilter(BaseMiddleware):
             dumpRequest = dumpResponse = True
 
         # Process URL commands
-        if environ.get("QUERY_STRING"):
-            if "dump_storage" in environ.get("QUERY_STRING"):
-                dav = environ.get("wsgidav.provider")
-                if dav.lockManager:
-                    dav.lockManager._dump()
-                if dav.propManager:
-                    dav.propManager._dump()
+        if "dump_storage" in environ.get("QUERY_STRING", ""):
+            dav = environ.get("wsgidav.provider")
+            if dav.lockManager:
+                dav.lockManager._dump()
+            if dav.propManager:
+                dav.propManager._dump()
 
         # Turn on max. debugging for selected litmus tests
         litmusTag = environ.get(

--- a/wsgidav/debug_filter.py
+++ b/wsgidav/debug_filter.py
@@ -99,12 +99,13 @@ class WsgiDavDebugFilter(BaseMiddleware):
             dumpRequest = dumpResponse = True
 
         # Process URL commands
-        if "dump_storage" in environ.get("QUERY_STRING"):
-            dav = environ.get("wsgidav.provider")
-            if dav.lockManager:
-                dav.lockManager._dump()
-            if dav.propManager:
-                dav.propManager._dump()
+        if environ.get("QUERY_STRING"):
+            if "dump_storage" in environ.get("QUERY_STRING"):
+                dav = environ.get("wsgidav.provider")
+                if dav.lockManager:
+                    dav.lockManager._dump()
+                if dav.propManager:
+                    dav.propManager._dump()
 
         # Turn on max. debugging for selected litmus tests
         litmusTag = environ.get(


### PR DESCRIPTION
This is giving me an exception when running as wsgi app under eventlet,
with Python3. A variable is not defined instead of empty string in this
case causing the error. The patch avoids the error in this case.