### PR TITLE
Give custom PropertyManager implementations access to the environ

### DIFF
--- a/wsgidav/addons/couch_property_manager.py
+++ b/wsgidav/addons/couch_property_manager.py
@@ -131,7 +131,7 @@ class CouchPropertyManager(object):
             yield row.doc
         return
 
-    def getProperties(self, normurl):
+    def getProperties(self, normurl, environ=None):
         _logger.debug("getProperties(%s)" % normurl)
         doc = self._find(normurl)
         propNames = []
@@ -140,7 +140,7 @@ class CouchPropertyManager(object):
                 propNames.append(name)
         return propNames
 
-    def getProperty(self, normurl, propname):
+    def getProperty(self, normurl, propname, environ=None):
         _logger.debug("getProperty(%s, %s)" % (normurl, propname))
         doc = self._find(normurl)
         if not doc:
@@ -148,7 +148,7 @@ class CouchPropertyManager(object):
         prop = doc["properties"].get(propname)
         return prop
 
-    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False):
+    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False, environ=None):
         assert normurl and normurl.startswith("/")
         assert propname
         assert propertyvalue is not None
@@ -170,7 +170,7 @@ class CouchPropertyManager(object):
                    }
         self.db.save(doc)
 
-    def removeProperty(self, normurl, propname, dryRun=False):
+    def removeProperty(self, normurl, propname, dryRun=False, environ=None):
         _logger.debug("removeProperty(%s, %s, dryRun=%s)" % (normurl, propname, dryRun))
         if dryRun:
             # TODO: can we check anything here?
@@ -182,14 +182,14 @@ class CouchPropertyManager(object):
         del doc["properties"][propname]
         self.db.save(doc)
 
-    def removeProperties(self, normurl):
+    def removeProperties(self, normurl, environ=None):
         _logger.debug("removeProperties(%s)" % normurl)
         doc = self._find(normurl)
         if doc:
             self.db.delete(doc)
         return
 
-    def copyProperties(self, srcUrl, destUrl):
+    def copyProperties(self, srcUrl, destUrl, environ=None):
         doc = self._find(srcUrl)
         if not doc:
             _logger.debug("copyProperties(%s, %s): src has no properties" % (srcUrl, destUrl))
@@ -204,7 +204,7 @@ class CouchPropertyManager(object):
                 }
         self.db.save(doc2)
 
-    def moveProperties(self, srcUrl, destUrl, withChildren):
+    def moveProperties(self, srcUrl, destUrl, withChildren, environ=None):
         _logger.debug("moveProperties(%s, %s, %s)" % (srcUrl, destUrl, withChildren))
         if withChildren:
             # Match URLs that are equal to <srcUrl> or begin with '<srcUrl>/'

--- a/wsgidav/addons/mongo_property_manager.py
+++ b/wsgidav/addons/mongo_property_manager.py
@@ -95,7 +95,7 @@ class MongoPropertyManager(object):
     def _dump(self, msg="", out=None):
         pass
 
-    def getProperties(self, normurl):
+    def getProperties(self, normurl, environ=None):
         _logger.debug("getProperties(%s)" % normurl)
         doc = self.collection.find_one({"_url": normurl})
         propNames = []
@@ -105,7 +105,7 @@ class MongoPropertyManager(object):
                     propNames.append(decodeMongoKey(name))
         return propNames
 
-    def getProperty(self, normurl, propname):
+    def getProperty(self, normurl, propname, environ=None):
         _logger.debug("getProperty(%s, %s)" % (normurl, propname))
         doc = self.collection.find_one({"_url": normurl})
         if not doc:
@@ -113,7 +113,7 @@ class MongoPropertyManager(object):
         prop = doc.get(encodeMongoKey(propname))
         return prop
 
-    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False):
+    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False, environ=None):
         assert normurl and normurl.startswith("/")
         assert propname
         assert propertyvalue is not None
@@ -132,7 +132,7 @@ class MongoPropertyManager(object):
         doc[encodeMongoKey(propname)] = propertyvalue
         self.collection.save(doc)
 
-    def removeProperty(self, normurl, propname, dryRun=False):
+    def removeProperty(self, normurl, propname, dryRun=False, environ=None):
         """
         """
         _logger.debug("removeProperty(%s, %s, dryRun=%s)" % (normurl, propname, dryRun))
@@ -146,14 +146,14 @@ class MongoPropertyManager(object):
         del doc[encodeMongoKey(propname)]
         self.collection.save(doc)
 
-    def removeProperties(self, normurl):
+    def removeProperties(self, normurl, environ=None):
         _logger.debug("removeProperties(%s)" % normurl)
         doc = self.collection.find_one({"_url": normurl})
         if doc:
             self.collection.remove(doc)
         return
 
-    def copyProperties(self, srcUrl, destUrl):
+    def copyProperties(self, srcUrl, destUrl, environ=None):
         doc = self.collection.find_one({"_url": srcUrl})
         if not doc:
             _logger.debug("copyProperties(%s, %s): src has no properties" % (srcUrl, destUrl))
@@ -162,7 +162,7 @@ class MongoPropertyManager(object):
         doc2 = doc.copy()
         self.collection.insert(doc2)
 
-    def moveProperties(self, srcUrl, destUrl, withChildren):
+    def moveProperties(self, srcUrl, destUrl, withChildren, environ=None):
         _logger.debug("moveProperties(%s, %s, %s)" % (srcUrl, destUrl, withChildren))
         if withChildren:
             # Match URLs that are equal to <srcUrl> or begin with '<srcUrl>/'

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -518,7 +518,7 @@ class _DAVResource(object):
         if self.provider.propManager:
             refUrl = self.getRefUrl()
             propNameList.extend(
-                self.provider.propManager.getProperties(refUrl))
+                self.provider.propManager.getProperties(refUrl, self.environ))
 
         return propNameList
 
@@ -695,7 +695,7 @@ class _DAVResource(object):
         # Dead property
         pm = self.provider.propManager
         if pm:
-            value = pm.getProperty(refUrl, propname)
+            value = pm.getProperty(refUrl, propname, self.environ)
             if value is not None:
                 return xml_tools.stringToXML(value)
 
@@ -758,17 +758,17 @@ class _DAVResource(object):
         if pm and not propname.startswith("{DAV:}"):
             refUrl = self.getRefUrl()
             if value is None:
-                return pm.removeProperty(refUrl, propname, dryRun)
+                return pm.removeProperty(refUrl, propname, dryRun, self.environ)
             else:
                 value = etree.tostring(value)
-                return pm.writeProperty(refUrl, propname, value, dryRun)
+                return pm.writeProperty(refUrl, propname, value, dryRun, self.environ)
 
         raise DAVError(HTTP_FORBIDDEN)
 
     def removeAllProperties(self, recursive):
         """Remove all associated dead properties."""
         if self.provider.propManager:
-            self.provider.propManager.removeProperties(self.getRefUrl())
+            self.provider.propManager.removeProperties(self.getRefUrl(), self.environ)
 
     # --- Locking ------------------------------------------------------------
 
@@ -1466,8 +1466,8 @@ class DAVProvider(object):
         """Optionally implement custom request handling.
 
         requestmethod = environ["REQUEST_METHOD"]
-        Either 
-          - handle the request completely   
+        Either
+          - handle the request completely
           - do additional processing and call defaultHandler(environ, start_response)
         """
         return defaultHandler(environ, start_response)

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -131,9 +131,9 @@ class FileResource(DAVNonCollection):
             destRes = self.provider.getResourceInst(destPath, self.environ)
             if isMove:
                 propMan.moveProperties(self.getRefUrl(), destRes.getRefUrl(),
-                                       withChildren=False)
+                                       withChildren=False, environ=self.environ)
             else:
-                propMan.copyProperties(self.getRefUrl(), destRes.getRefUrl())
+                propMan.copyProperties(self.getRefUrl(), destRes.getRefUrl(), self.environ)
 
     def supportRecursiveMove(self, destPath):
         """Return True, if moveRecursive() is available (see comments there)."""
@@ -153,7 +153,7 @@ class FileResource(DAVNonCollection):
         if self.provider.propManager:
             destRes = self.provider.getResourceInst(destPath, self.environ)
             self.provider.propManager.moveProperties(self.getRefUrl(), destRes.getRefUrl(),
-                                                     withChildren=True)
+                                                     withChildren=True, environ=self.environ)
 
     def setLastModified(self, destPath, timeStamp, dryRun):
         """Set last modified time for destPath to timeStamp on epoch-format"""
@@ -306,9 +306,9 @@ class FolderResource(DAVCollection):
             destRes = self.provider.getResourceInst(destPath, self.environ)
             if isMove:
                 propMan.moveProperties(self.getRefUrl(), destRes.getRefUrl(),
-                                       withChildren=False)
+                                       withChildren=False, environ=self.environ)
             else:
-                propMan.copyProperties(self.getRefUrl(), destRes.getRefUrl())
+                propMan.copyProperties(self.getRefUrl(), destRes.getRefUrl(), self.environ)
 
     def supportRecursiveMove(self, destPath):
         """Return True, if moveRecursive() is available (see comments there)."""
@@ -328,7 +328,7 @@ class FolderResource(DAVCollection):
         if self.provider.propManager:
             destRes = self.provider.getResourceInst(destPath, self.environ)
             self.provider.propManager.moveProperties(self.getRefUrl(), destRes.getRefUrl(),
-                                                     withChildren=True)
+                                                     withChildren=True, environ=self.environ)
 
     def setLastModified(self, destPath, timeStamp, dryRun):
         """Set last modified time for destPath to timeStamp on epoch-format"""

--- a/wsgidav/property_manager.py
+++ b/wsgidav/property_manager.py
@@ -133,7 +133,7 @@ class PropertyManager(object):
         except Exception as e:
             util.warn("PropertyManager._dump()  ERROR: %s" % e)
 
-    def getProperties(self, normurl):
+    def getProperties(self, normurl, environ=None):
         _logger.debug("getProperties(%s)" % normurl)
         self._lock.acquireRead()
         try:
@@ -147,7 +147,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def getProperty(self, normurl, propname):
+    def getProperty(self, normurl, propname, environ=None):
         _logger.debug("getProperty(%s, %s)" % (normurl, propname))
         self._lock.acquireRead()
         try:
@@ -167,7 +167,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False):
+    def writeProperty(self, normurl, propname, propertyvalue, dryRun=False, environ=None):
         # self._log("writeProperty(%s, %s, dryRun=%s):\n\t%s" % (normurl,
         #   propname, dryRun, propertyvalue))
         assert normurl and normurl.startswith("/")
@@ -196,7 +196,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def removeProperty(self, normurl, propname, dryRun=False):
+    def removeProperty(self, normurl, propname, dryRun=False, environ=None):
         """
         Specifying the removal of a property that does not exist is NOT an error.
         """
@@ -222,7 +222,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def removeProperties(self, normurl):
+    def removeProperties(self, normurl, environ=None):
         _logger.debug("removeProperties(%s)" % normurl)
         self._lock.acquireWrite()
         try:
@@ -234,7 +234,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def copyProperties(self, srcurl, desturl):
+    def copyProperties(self, srcurl, desturl, environ=None):
         _logger.debug("copyProperties(%s, %s)" % (srcurl, desturl))
         self._lock.acquireWrite()
         try:
@@ -250,7 +250,7 @@ class PropertyManager(object):
         finally:
             self._lock.release()
 
-    def moveProperties(self, srcurl, desturl, withChildren):
+    def moveProperties(self, srcurl, desturl, withChildren, environ=None):
         _logger.debug("moveProperties(%s, %s, %s)" %
                       (srcurl, desturl, withChildren))
         self._lock.acquireWrite()


### PR DESCRIPTION
The DAV provider already has access to the environ, but the
PropertyManager didn't until now.  In my system both of these need to
know about the user making the request for access control / file
resolution purposes.