### PR TITLE
Don't assume sys.stdout.encoding is not None

### DIFF
--- a/wsgidav/dir_browser.py
+++ b/wsgidav/dir_browser.py
@@ -178,7 +178,7 @@ class WsgiDavDirBrowser(BaseMiddleware):
         """Wrapper to raise (and log) DAVError."""
         e = DAVError(value, contextinfo, srcexception, errcondition)
         if self._verbose >= 2:
-            print("Raising DAVError %s" % safeReEncode(e.getUserInfo(), sys.stdout.encoding),
+            print("Raising DAVError %s" % safeReEncode(e.getUserInfo(), sys.stdout.encoding or 'ASCII'),
                   file=sys.stdout)
         raise e
 

--- a/wsgidav/domain_controller.py
+++ b/wsgidav/domain_controller.py
@@ -61,7 +61,7 @@ class WsgiDAVDomainController(object):
         if not davProvider:
             if environ["wsgidav.verbose"] >= 2:
                 print("getDomainRealm(%s): '%s'"
-                      % (safeReEncode(inputURL, sys.stdout.encoding), None), file=sys.stdout)
+                      % (safeReEncode(inputURL, sys.stdout.encoding or 'ASCII'), None), file=sys.stdout)
             return None
         realm = davProvider.sharePath
         if realm == "":

--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -421,7 +421,7 @@ class WsgiDAVApp(object):
                     userInfo,
                     util.getLogTime(),
                     environ.get("REQUEST_METHOD") + " " +
-                    safeReEncode(environ.get("PATH_INFO", ""), sys.stdout.encoding),
+                    safeReEncode(environ.get("PATH_INFO", ""), sys.stdout.encoding or 'ASCII'),
                     extra,
                     status,
                     # response_headers.get(""), # response Content-Length


### PR DESCRIPTION
Supply the same default as Python will - 'ASCII' - in this case.

I ran into this issue when running wsgidav within PyCharm.  Python does not detect the output encoding and `sys.stdout.encoding` is `None`, which causes an error inside `safeReEncode`.
