### PR TITLE
python3 bug fix (second attempt): WSGI expects binary instead of str

### DIFF
--- a/wsgidav/samples/virtual_dav_provider.py
+++ b/wsgidav/samples/virtual_dav_provider.py
@@ -519,7 +519,7 @@ class VirtualArtifact(_VirtualNonCollection):
             html = self.data["description"]
         else:
             raise DAVError(HTTP_INTERNAL_ERROR, "Invalid artifact '%s'" % self.name)
-        return compat.StringIO(html)
+        return compat.BytesIO(compat.to_bytes(html))
 
 
 # ============================================================================


### PR DESCRIPTION
Second attempt to get virtual_dav_provider.py running under python 3 after pull request #98 didn't work. Tested with python 3.6 and 2.7.