### PR TITLE
Added support for supplying ETags on PUT.

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -780,9 +780,16 @@ class RequestServer(object):
 
         res.endWrite(hasErrors)
 
+        def tagged_start_response(status, headers, exc_info=None):
+            if res.supportEtag():
+                entitytag = res.getEtag()
+                if entitytag is not None:
+                    headers.append(("ETag", '"{}"'.format(entitytag)))
+            return start_response(status, headers, exc_info)
+
         if isnewfile:
-            return util.sendStatusResponse(environ, start_response, HTTP_CREATED)
-        return util.sendStatusResponse(environ, start_response, HTTP_NO_CONTENT)
+            return util.sendStatusResponse(environ, tagged_start_response, HTTP_CREATED)
+        return util.sendStatusResponse(environ, tagged_start_response, HTTP_NO_CONTENT)
 
     def doCOPY(self, environ, start_response):
         return self._copyOrMove(environ, start_response, False)


### PR DESCRIPTION
I found Tiddlywiki was expecting this apparently MS server does it.
It makes sense and I'd like to use it in another javascript app I'm
using. Avoids one request.

Note I also sent a [fix to Tiddlywiki](https://github.com/Jermolene/TiddlyWiki5/pull/3230) to work with WSGIDav as is - but this ways seems more efficient.