### PR TITLE
Checking if buffer is empty bytestring

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -649,7 +649,7 @@ class RequestServer(object):
             else:
                 environ["wsgi.input"].readline()
                 buf = environ["wsgi.input"].readline()
-                if buf == "":
+                if buf == "" or buf == b"":
                     length = 0
                 else:
                     length = int(buf, 16)


### PR DESCRIPTION
When creating an empty temporaryfile from python3 and try to upload such file to wsgidav, wsgidav fails:
```invalid literal for int() with base 16: b''```

This fixes such condition, though I don't know why `leng(buf)` is not used in a first place.