### PR TITLE
revert nsmap argument conversion

### DIFF
--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -904,7 +904,7 @@ def add_property_response(multistatusEL, href, propList):
         propDict.setdefault(status, []).append((name, value))
 
     # <response>
-    responseEL = make_sub_element(multistatusEL, "{DAV:}response", ns_map=nsMap)
+    responseEL = make_sub_element(multistatusEL, "{DAV:}response", nsmap=nsMap)
 
     #    log("href value:{}".format(string_repr(href)))
     #    etree.SubElement(responseEL, "{DAV:}href").text = toUnicode(href)

--- a/wsgidav/xml_tools.py
+++ b/wsgidav/xml_tools.py
@@ -90,23 +90,23 @@ def xml_to_bytes(element, pretty_print=False):
 
 
 def make_multistatus_el():
-    """Wrapper for etree.Element, that takes care of unsupported ns_map option."""
+    """Wrapper for etree.Element, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.Element("{DAV:}multistatus", ns_map={"D": "DAV:"})
+        return etree.Element("{DAV:}multistatus", nsmap={"D": "DAV:"})
     return etree.Element("{DAV:}multistatus")
 
 
 def make_prop_el():
-    """Wrapper for etree.Element, that takes care of unsupported ns_map option."""
+    """Wrapper for etree.Element, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.Element("{DAV:}prop", ns_map={"D": "DAV:"})
+        return etree.Element("{DAV:}prop", nsmap={"D": "DAV:"})
     return etree.Element("{DAV:}prop")
 
 
-def make_sub_element(parent, tag, ns_map=None):
-    """Wrapper for etree.SubElement, that takes care of unsupported ns_map option."""
+def make_sub_element(parent, tag, nsmap=None):
+    """Wrapper for etree.SubElement, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.SubElement(parent, tag, ns_map=ns_map)
+        return etree.SubElement(parent, tag, nsmap=nsmap)
     return etree.SubElement(parent, tag)
 
 


### PR DESCRIPTION
revert unwanted conversion introduced in https://github.com/mar10/wsgidav/pull/124

without this I get:

`  File "C:\data\vendor\wsgidav\wsgidav\request_resolver.py", line 205, in __call__
    for v in app_iter:

  File "C:\data\vendor\wsgidav\wsgidav\request_server.py", line 125, in __call__
    app_iter = provider.custom_request_handler(environ, start_response, method)

  File "C:\data\vendor\wsgidav\wsgidav\dav_provider.py", line 1527, in custom_request_handler
    return default_handler(environ, start_response)

  File "C:\data\vendor\wsgidav\wsgidav\request_server.py", line 352, in do_PROPFIND
    multistatusEL = xml_tools.make_multistatus_el()

  File "C:\data\vendor\wsgidav\wsgidav\xml_tools.py", line 95, in make_multistatus_el
    return etree.Element("{DAV:}multistatus", ns_map={"D": "DAV:"})

  File "lxml.etree.pyx", line 2841, in lxml.etree.Element (src\lxml\lxml.etree.c:66367)

  File "apihelpers.pxi", line 140, in lxml.etree._makeElement (src\lxml\lxml.etree.c:15101)

  File "apihelpers.pxi", line 128, in lxml.etree._makeElement (src\lxml\lxml.etree.c:14980)

  File "apihelpers.pxi", line 275, in lxml.etree._initNodeAttributes (src\lxml\lxml.etree.c:16528)
TypeError: Argument must be bytes or unicode, got 'dict'`
