### PR TITLE
Rename revert

### DIFF
--- a/tests/davclient.py
+++ b/tests/davclient.py
@@ -406,8 +406,8 @@ class DAVClient(object):
         object_to_etree(
             root,
             {
-                "lock_type": lock_type,
-                "lock_scope": lock_scope,
+                "locktype": lock_type,
+                "lockscope": lock_scope,
                 "owner": {"href": owner},
             },
             namespace="DAV:",
@@ -426,7 +426,7 @@ class DAVClient(object):
 
         self._request("LOCK", path, body=body, headers=headers)
 
-        locks = self.response.tree.findall(".//{DAV:}lock_token")
+        locks = self.response.tree.findall(".//{DAV:}locktoken")
         lock_list = []
         for lock in locks:
             lock_list.append(lock[0].text.strip().strip("\n"))

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -618,11 +618,11 @@ class _DAVResource(object):
             for lock in activelocklist:
                 activelockEL = etree.SubElement(lockdiscoveryEL, "{DAV:}activelock")
 
-                locktypeEL = etree.SubElement(activelockEL, "{DAV:}lock_type")
+                locktypeEL = etree.SubElement(activelockEL, "{DAV:}locktype")
                 # Note: make sure `{DAV:}` is not handled as format tag:
                 etree.SubElement(locktypeEL, "{}{}".format("{DAV:}", lock["type"]))
 
-                lockscopeEL = etree.SubElement(activelockEL, "{DAV:}lock_scope")
+                lockscopeEL = etree.SubElement(activelockEL, "{DAV:}lockscope")
                 # Note: make sure `{DAV:}` is not handled as format tag:
                 etree.SubElement(lockscopeEL, "{}{}".format("{DAV:}", lock["scope"]))
 
@@ -642,7 +642,7 @@ class _DAVResource(object):
                     timeout = "Second-" + str(int(expire - time.time()))
                 etree.SubElement(activelockEL, "{DAV:}timeout").text = timeout
 
-                locktokenEL = etree.SubElement(activelockEL, "{DAV:}lock_token")
+                locktokenEL = etree.SubElement(activelockEL, "{DAV:}locktoken")
                 etree.SubElement(locktokenEL, "{DAV:}href").text = lock["token"]
 
                 # TODO: this is ugly:
@@ -665,15 +665,15 @@ class _DAVResource(object):
             supportedlockEL = etree.Element(name)
 
             lockentryEL = etree.SubElement(supportedlockEL, "{DAV:}lockentry")
-            lockscopeEL = etree.SubElement(lockentryEL, "{DAV:}lock_scope")
+            lockscopeEL = etree.SubElement(lockentryEL, "{DAV:}lockscope")
             etree.SubElement(lockscopeEL, "{DAV:}exclusive")
-            locktypeEL = etree.SubElement(lockentryEL, "{DAV:}lock_type")
+            locktypeEL = etree.SubElement(lockentryEL, "{DAV:}locktype")
             etree.SubElement(locktypeEL, "{DAV:}write")
 
             lockentryEL = etree.SubElement(supportedlockEL, "{DAV:}lockentry")
-            lockscopeEL = etree.SubElement(lockentryEL, "{DAV:}lock_scope")
+            lockscopeEL = etree.SubElement(lockentryEL, "{DAV:}lockscope")
             etree.SubElement(lockscopeEL, "{DAV:}shared")
-            locktypeEL = etree.SubElement(lockentryEL, "{DAV:}lock_type")
+            locktypeEL = etree.SubElement(lockentryEL, "{DAV:}locktype")
             etree.SubElement(locktypeEL, "{DAV:}write")
 
             return supportedlockEL

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1249,14 +1249,14 @@ class RequestServer(object):
         lock_depth = environ.setdefault("HTTP_DEPTH", "infinity")
 
         for linode in lockinfoEL:
-            if linode.tag == "{DAV:}lock_scope":
+            if linode.tag == "{DAV:}lockscope":
                 for lsnode in linode:
                     if lsnode.tag == "{DAV:}exclusive":
                         lock_scope = "exclusive"
                     elif lsnode.tag == "{DAV:}shared":
                         lock_scope = "shared"
                     break
-            elif linode.tag == "{DAV:}lock_type":
+            elif linode.tag == "{DAV:}locktype":
                 for ltnode in linode:
                     if ltnode.tag == "{DAV:}write":
                         lock_type = "write"  # only type accepted
@@ -1270,9 +1270,9 @@ class RequestServer(object):
                 self._fail(HTTP_BAD_REQUEST, "Invalid node '{}'.".format(linode.tag))
 
         if not lock_scope:
-            self._fail(HTTP_BAD_REQUEST, "Missing or invalid lock_scope.")
+            self._fail(HTTP_BAD_REQUEST, "Missing or invalid lockscope.")
         if not lock_type:
-            self._fail(HTTP_BAD_REQUEST, "Missing or invalid lock_type.")
+            self._fail(HTTP_BAD_REQUEST, "Missing or invalid locktype.")
 
         if environ.get("wsgidav.debug_break"):
             pass  # break point

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -904,7 +904,7 @@ def add_property_response(multistatusEL, href, propList):
         propDict.setdefault(status, []).append((name, value))
 
     # <response>
-    responseEL = make_sub_element(multistatusEL, "{DAV:}response", ns_map=nsMap)
+    responseEL = make_sub_element(multistatusEL, "{DAV:}response", nsmap=nsMap)
 
     #    log("href value:{}".format(string_repr(href)))
     #    etree.SubElement(responseEL, "{DAV:}href").text = toUnicode(href)

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -1222,7 +1222,7 @@ def parse_if_header_dict(environ):
                         )
                     else:
                         listTagContents.append(
-                            (testflag, "lock_token", listitem.strip("<>"))
+                            (testflag, "locktoken", listitem.strip("<>"))
                         )
                         ifLockList.append(listitem.strip("<>"))
                 testflag = listitem.upper() != "NOT"
@@ -1262,7 +1262,7 @@ def test_if_header_dict(dav_res, dictIf, fullurl, locktokenlist, entitytag):
                 testresult = entitytag == checkvalue
             elif checkstyle == "entity":
                 testresult = testflag
-            elif checkstyle == "lock_token":
+            elif checkstyle == "locktoken":
                 testresult = checkvalue in locktokenlist
             else:  # unknown
                 testresult = True

--- a/wsgidav/xml_tools.py
+++ b/wsgidav/xml_tools.py
@@ -90,23 +90,23 @@ def xml_to_bytes(element, pretty_print=False):
 
 
 def make_multistatus_el():
-    """Wrapper for etree.Element, that takes care of unsupported ns_map option."""
+    """Wrapper for etree.Element, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.Element("{DAV:}multistatus", ns_map={"D": "DAV:"})
+        return etree.Element("{DAV:}multistatus", nsmap={"D": "DAV:"})
     return etree.Element("{DAV:}multistatus")
 
 
 def make_prop_el():
-    """Wrapper for etree.Element, that takes care of unsupported ns_map option."""
+    """Wrapper for etree.Element, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.Element("{DAV:}prop", ns_map={"D": "DAV:"})
+        return etree.Element("{DAV:}prop", nsmap={"D": "DAV:"})
     return etree.Element("{DAV:}prop")
 
 
-def make_sub_element(parent, tag, ns_map=None):
-    """Wrapper for etree.SubElement, that takes care of unsupported ns_map option."""
+def make_sub_element(parent, tag, nsmap=None):
+    """Wrapper for etree.SubElement, that takes care of unsupported nsmap option."""
     if use_lxml:
-        return etree.SubElement(parent, tag, ns_map=ns_map)
+        return etree.SubElement(parent, tag, nsmap=nsmap)
     return etree.SubElement(parent, tag)
 
 


### PR DESCRIPTION
Revert https://github.com/mar10/wsgidav/pull/124

"locktype", "lockscope" and "locktoken" must be left without underscores when used in XML

nsmap to ns_map conversion leads to:
` 
  File "C:\data\vendor\wsgidav\wsgidav\xml_tools.py", line 95, in make_multistatus_el
    return etree.Element("{DAV:}multistatus", ns_map={"D": "DAV:"})ˇ

  File "lxml.etree.pyx", line 2841, in lxml.etree.Element (src\lxml\lxml.etree.c:66367)

  File "apihelpers.pxi", line 140, in lxml.etree._makeElement (src\lxml\lxml.etree.c:15101)

  File "apihelpers.pxi", line 128, in lxml.etree._makeElement (src\lxml\lxml.etree.c:14980)

  File "apihelpers.pxi", line 275, in lxml.etree._initNodeAttributes (src\lxml\lxml.etree.c:16528)
TypeError: Argument must be bytes or unicode, got 'dict'`

