### PR TITLE
Allow dav providers to access the raw wsgi file object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 3.0.1 / Unreleased
+- Fix #152: "Allow-Ranges: bytes" is now correct "Accept-Ranges: bytes" header
+- Merge #155: last_modified is now correctly cast to int when comparing conditional requests
+- Merge #156: the file object returned by get_content (DAVNonCollection) is now correctly being closed when a client disconnects unexpectedly
 
 ## 3.0.0 / 2019-03-04
 

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -234,7 +234,7 @@ class RequestServer(object):
         last_modified = -1  # nonvalid modified time
         entitytag = "[]"  # Non-valid entity tag
         if res.get_last_modified() is not None:
-            last_modified = res.get_last_modified()
+            last_modified = int(res.get_last_modified())
         if res.get_etag() is not None:
             entitytag = res.get_etag()
 
@@ -1548,7 +1548,8 @@ class RequestServer(object):
             # Try as http-date first (Return None, if invalid date string)
             secstime = util.parse_time_string(ifrange)
             if secstime:
-                if last_modified != secstime:
+                # cast to integer, as last_modified may be a floating point number
+                if int(last_modified) != secstime:
                     doignoreranges = True
             else:
                 # Use as entity tag

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1625,17 +1625,24 @@ class RequestServer(object):
             fileobj.seek(range_start)
 
         contentlengthremaining = range_length
-        while 1:
-            if contentlengthremaining < 0 or contentlengthremaining > self.block_size:
-                readbuffer = fileobj.read(self.block_size)
-            else:
-                readbuffer = fileobj.read(contentlengthremaining)
-            assert compat.is_bytes(readbuffer)
-            yield readbuffer
-            contentlengthremaining -= len(readbuffer)
-            if len(readbuffer) == 0 or contentlengthremaining == 0:
-                break
-        fileobj.close()
+        try:
+            while 1:
+                if (
+                    contentlengthremaining < 0
+                    or contentlengthremaining > self.block_size
+                ):
+                    readbuffer = fileobj.read(self.block_size)
+                else:
+                    readbuffer = fileobj.read(contentlengthremaining)
+                assert compat.is_bytes(readbuffer)
+                yield readbuffer
+                contentlengthremaining -= len(readbuffer)
+                if len(readbuffer) == 0 or contentlengthremaining == 0:
+                    break
+        finally:
+            # yield readbuffer MAY fail with a GeneratorExit error
+            # we still need to close the file
+            fileobj.close()
         return
 
 

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1466,7 +1466,7 @@ class RequestServer(object):
                 if provider.lock_manager is not None:
                     allow.extend(["LOCK", "UNLOCK"])
             if res.support_ranges():
-                headers.append(("Allow-Ranges", "bytes"))
+                headers.append(("Accept-Ranges", "bytes"))
         elif provider.is_collection(util.get_uri_parent(path), environ):
             # A new resource below an existing collection
             # TODO: should we allow LOCK here? I think it is allowed to lock an
@@ -1589,6 +1589,9 @@ class RequestServer(object):
         response_headers.append(("Date", util.get_rfc1123_time()))
         if res.support_etag():
             response_headers.append(("ETag", '"{}"'.format(entitytag)))
+
+        if res.support_ranges():
+            response_headers.append(("Accept-Ranges", "bytes"))
 
         if "response_headers" in environ["wsgidav.config"]:
             customHeaders = environ["wsgidav.config"]["response_headers"]

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -1174,7 +1174,7 @@ def evaluate_http_conditionals(dav_res, last_modified, entitytag, environ):
 
     if "HTTP_IF_UNMODIFIED_SINCE" in environ and dav_res.support_modified():
         ifunmodtime = parse_time_string(environ["HTTP_IF_UNMODIFIED_SINCE"])
-        if ifunmodtime and ifunmodtime <= last_modified:
+        if ifunmodtime and ifunmodtime < last_modified:
             raise DAVError(
                 HTTP_PRECONDITION_FAILED, "If-Unmodified-Since header condition failed"
             )


### PR DESCRIPTION
I'm currently writing an app that allows uploading files using WebDAV. For file storage I'm using S3. boto3 has an api for uploading file like objects (`s3.upload_fileobj`) without reading everything into memory, therefore I need to access the raw wsgi file object from the dav provider:

```python
class FileResource(DAVNonCollection):
    ...
    def upload_fileobj(self, file):
            s3.upload_fileobj(file, "my-bucket", "my-filekey")
```

This is one of my first pull requests so you should rather see this as a suggestion. Maybe you even know a better solution for this problem.

Thanks for the great work!