### PR TITLE
Cast last_modified value to integer when comparing ifrange requests

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1548,7 +1548,8 @@ class RequestServer(object):
             # Try as http-date first (Return None, if invalid date string)
             secstime = util.parse_time_string(ifrange)
             if secstime:
-                if last_modified != secstime:
+                # cast to integer, as last_modified may be a floating point number
+                if int(last_modified) != secstime:
                     doignoreranges = True
             else:
                 # Use as entity tag

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -234,7 +234,7 @@ class RequestServer(object):
         last_modified = -1  # nonvalid modified time
         entitytag = "[]"  # Non-valid entity tag
         if res.get_last_modified() is not None:
-            last_modified = res.get_last_modified()
+            last_modified = int(res.get_last_modified())
         if res.get_etag() is not None:
             entitytag = res.get_etag()
 

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -1174,7 +1174,7 @@ def evaluate_http_conditionals(dav_res, last_modified, entitytag, environ):
 
     if "HTTP_IF_UNMODIFIED_SINCE" in environ and dav_res.support_modified():
         ifunmodtime = parse_time_string(environ["HTTP_IF_UNMODIFIED_SINCE"])
-        if ifunmodtime and ifunmodtime <= last_modified:
+        if ifunmodtime and ifunmodtime < last_modified:
             raise DAVError(
                 HTTP_PRECONDITION_FAILED, "If-Unmodified-Since header condition failed"
             )


### PR DESCRIPTION
https://github.com/mar10/wsgidav/blob/cec0d84222fc24bea01be1cea91729001963f172/wsgidav/request_server.py#L1551
We should cast to an int here, as the dav_provider never specified that last_modified has to be a whole number. I'm currently using datetime.timestamp() which is returning a float.

This fixed an error for me, where Chrome tries to download a 2.7GB file instead of making a range request.