### PR TITLE
Close file properly when client disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 3.0.1 / Unreleased
+- Fix #152: "Allow-Ranges: bytes" is now correct "Accept-Ranges: bytes" header
+- Merge #155: last_modified is now correctly cast to int when comparing conditional requests
+- Merge #156: the file object returned by get_content (DAVNonCollection) is now correctly being closed when a client disconnects unexpectedly
 
 ## 3.0.0 / 2019-03-04
 

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1623,7 +1623,10 @@ class RequestServer(object):
         contentlengthremaining = range_length
         try:
             while 1:
-                if contentlengthremaining < 0 or contentlengthremaining > self.block_size:
+                if (
+                    contentlengthremaining < 0
+                    or contentlengthremaining > self.block_size
+                ):
                     readbuffer = fileobj.read(self.block_size)
                 else:
                     readbuffer = fileobj.read(contentlengthremaining)

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1621,17 +1621,21 @@ class RequestServer(object):
             fileobj.seek(range_start)
 
         contentlengthremaining = range_length
-        while 1:
-            if contentlengthremaining < 0 or contentlengthremaining > self.block_size:
-                readbuffer = fileobj.read(self.block_size)
-            else:
-                readbuffer = fileobj.read(contentlengthremaining)
-            assert compat.is_bytes(readbuffer)
-            yield readbuffer
-            contentlengthremaining -= len(readbuffer)
-            if len(readbuffer) == 0 or contentlengthremaining == 0:
-                break
-        fileobj.close()
+        try:
+            while 1:
+                if contentlengthremaining < 0 or contentlengthremaining > self.block_size:
+                    readbuffer = fileobj.read(self.block_size)
+                else:
+                    readbuffer = fileobj.read(contentlengthremaining)
+                assert compat.is_bytes(readbuffer)
+                yield readbuffer
+                contentlengthremaining -= len(readbuffer)
+                if len(readbuffer) == 0 or contentlengthremaining == 0:
+                    break
+        finally:
+            # yield readbuffer MAY fail with a GeneratorExit error
+            # we still need to close the file
+            fileobj.close()
         return
 
 


### PR DESCRIPTION
https://github.com/mar10/wsgidav/blob/cec0d84222fc24bea01be1cea91729001963f172/wsgidav/request_server.py#L1624-L1634

Currently, fileobj.close() is never called when a client just drops the connection, as yielding throws a GeneratorExit exception.