### PR TITLE
Use gevent.pywsgi as default server, fixes #149

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
           env: TOXENV=lint-py27
         - python: "3.7"
           env: TOXENV=black-check,lint-py37
+          dist: xenial
         - python: "2.7"
           env: TOXENV=py27
         - python: "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ matrix:
     include:
         - python: "2.7"
           env: TOXENV=lint-py27
-        - python: "3.6"
-          env: TOXENV=black-check,lint-py36
+        - python: "3.7"
+          env: TOXENV=black-check,lint-py37
         - python: "2.7"
           env: TOXENV=py27
         - python: "3.4"
@@ -18,13 +18,9 @@ matrix:
         - python: "3.7"
           env: TOXENV=py37
           dist: xenial
-        - python: "3.7-dev"
-          env: TOXENV=py37
         - python: "3.8-dev"
           env: TOXENV=py38
     allow_failures:
-        - python: "3.7-dev"
-          env: TOXENV=py37
         - python: "3.8-dev"
           env: TOXENV=py38
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix #152: "Allow-Ranges: bytes" is now correct "Accept-Ranges: bytes" header
 - Merge #155: last_modified is now correctly cast to int when comparing conditional requests
 - Merge #156: the file object returned by get_content (DAVNonCollection) is now correctly being closed when a client disconnects unexpectedly
+- Use gevent as default WSGI server as cheroot has performance issues with windows clients
 
 ## 3.0.0 / 2019-03-04
 
@@ -16,7 +17,7 @@ This release contains **BREAKING CHANGES!**
     override those.
   - Log format is configurable
   - Remove option `dir_browser.enabled` (modify `middleware_stack` instead)
-  - CLI supports `--server=gevent` (gevent must be installed separately)
+  - CLI supports `--server=cheroot` (cheroot must be installed separately)
   - SSL paths are evaluated relative to the config file, if any
   - Refactor middleware stack
     - RequestResolver and WsgiDavDirBrowser are now simple members of `middleware_stack`

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3-alpine
 # Compile dependencies to pip install lxml (including alpine musl libc)
 RUN apk --no-cache add gcc libxslt-dev musl-dev
 
-RUN pip install --no-cache-dir wsgidav cheroot lxml
+RUN pip install --no-cache-dir wsgidav gevent lxml
 RUN mkdir -p /var/wsgidav-root
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Main features:
   - WsgiDAV is a stand-alone WebDAV server with SSL support, that can be
     installed and run as Python command line script on Linux, OSX, and Windows:<br>
     ```
-    $ pip install wsgidav cheroot
+    $ pip install gevent cheroot
     $ wsgidav --host=0.0.0.0 --port=8080 --root=/tmp
     WARNING: share '/' will allow anonymous access.
-    Running WsgiDAV/2.2.2 Cheroot/5.5.0 Python/3.4.2
+    Running WsgiDAV/3.0.1 gevent/1.4.0 Python/3.7.3
     Serving on http://0.0.0.0:8080 ...
     ```
     Run `wsgidav --help` for a list of available options.<br>

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -53,7 +53,7 @@ Quickstart
 Releases are hosted on `PyPI <https://pypi.python.org/pypi/WsgiDAV>`_.
 Install WsgiDAV (and a server) like::
 
-  $ pip install cheroot wsgidav
+  $ pip install gevent wsgidav
 
 .. note::
    MS Windows users that only need the command line interface may prefer the

--- a/doc/sphinx/user_guide_access.rst
+++ b/doc/sphinx/user_guide_access.rst
@@ -17,7 +17,7 @@ WsgiDAV was tested with these clients
   * Microsoft® Office 2013
   * OpenOffice 3.1
   * Ubuntu Nautilus / gvfs
-  * Mac OS/X Finder
+  * macOS Finder
 
 The following examples assume, that we have a running WsgiDAV server on a remote
 machine with this configuration:
@@ -199,8 +199,8 @@ To unmount::
 
 Mac
 ===
-OS/X Finder
------------
+macOS Finder
+------------
 In the Finder menu, choose `Go` and `Connect to Server...`.
 
  1. Enter the URI of the WsgiDAV server: `http://192.168.0.2/dav`

--- a/doc/sphinx/user_guide_cli.rst
+++ b/doc/sphinx/user_guide_cli.rst
@@ -5,7 +5,7 @@ Command Line Interface
 
 The WsgiDAV server was tested with these platforms
 
-  * Mac OS X 10.9 - 10.13
+  * Mac OS X 10.9 - 10.14
   * Ubuntu 13 - 16
   * Windows (Win 7 - 10, Vista, XP)
 

--- a/doc/sphinx/user_guide_lib.rst
+++ b/doc/sphinx/user_guide_lib.rst
@@ -31,6 +31,7 @@ Run Inside a WSGI Server
 
 The WsgiDAV server was tested with these WSGI servers:
 
+  * gevent
   * Cheroot
   * cherrypy.wsgiserver
   * paste.httpserver
@@ -52,16 +53,16 @@ Here we keep most of the default options and use the
       "port": 8080,
       "provider_mapping": {
           "/": "/Users/joe/pub",
-          },
+      },
       "verbose": 1,
-      }
+  }
 
   app = WsgiDAVApp(config)
 
   server_args = {
       "bind_addr": (config["host"], config["port"]),
       "wsgi_app": app,
-      }
+  }
   server = wsgi.Server(**server_args)
   server.start()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 
 -r requirements.txt
 
+cheroot~=6.5.4
 gevent~=1.4.0
 # Installed by PS script from vendored wheel (see release_wsgidav.ps1):
 #cx_Freeze

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 -r requirements.txt
 
-cheroot~=6.5
+gevent~=1.4.0
 # Installed by PS script from vendored wheel (see release_wsgidav.ps1):
 #cx_Freeze
 Paste~=2.0

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,8 @@ if use_cx_freeze:
         [
             "cheroot",
             "cheroot.ssl.builtin",
+            "gevent",
+            "gevent.time",
             "lxml",
             # "win32",
             "wsgidav.dc.nt_dc",

--- a/tests/util.py
+++ b/tests/util.py
@@ -146,9 +146,9 @@ def run_wsgidav_server(with_auth, with_ssl, provider=None, **kwargs):
 
     # from wsgidav.server.server_cli import _runBuiltIn
     # _runBuiltIn(app, config, None)
-    from wsgidav.server.server_cli import _run_cheroot
+    from wsgidav.server.server_cli import _run_gevent
 
-    _run_cheroot(app, config, "cheroot")
+    _run_gevent(app, config, "gevent")
     # blocking...
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-basepython = python3.6
+basepython = python3.7
 envlist =
     py27,
     py34,
@@ -26,7 +26,7 @@ commands =
     pip list
     pytest -ra -v -x --cov=wsgidav --cov-report=xml --html=_build/pytest/report-{envname}.html --self-contained-html {posargs}
 deps =
-    cheroot
+    gevent
     defusedxml
     Jinja2
     jsmin
@@ -124,7 +124,7 @@ commands =
 
 
 [testenv:lint-py36]
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
     {[lint]deps}
@@ -146,7 +146,7 @@ commands =
 
 [testenv:black-check]
 description = Check Black formatting compliance and add flake8-bugbear checks
-basepython = python3.6
+basepython = python3.7
 changedir = {toxinidir}
 skip_install = true
 deps =
@@ -170,7 +170,7 @@ commands =
 
 [testenv:docs]
 description = Build Sphinx documentation (output directory: docs/sphinx-build)
-basepython = python3.6
+basepython = python3.7
 changedir = doc
 deps =
     sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py37,
     black-check,
     lint-py27,
-    lint-py36,
+    lint-py37,
     coverage,
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ commands =
     flake8 wsgidav setup.py --doctests
 
 
-[testenv:lint-py36]
+[testenv:lint-py37]
 basepython = python3.7
 skip_install = true
 deps =

--- a/wsgidav/default_conf.py
+++ b/wsgidav/default_conf.py
@@ -27,7 +27,7 @@ __docformat__ = "reStructuredText"
 DEFAULT_VERBOSE = 3
 
 DEFAULT_CONFIG = {
-    "server": "cheroot",
+    "server": "gevent",
     "server_args": {},
     "host": "localhost",
     "port": 8080,

--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -555,6 +555,9 @@ class WsgiDAVApp(object):
                         # referer
                     )
                 )
+
+            # override server name
+            response_headers.append(("Server", "WsgiDAV {}".format(__version__)))
             return start_response(status, response_headers, exc_info)
 
         # Call first middleware

--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -557,7 +557,8 @@ class WsgiDAVApp(object):
                 )
 
             # override server name
-            response_headers.append(("Server", "WsgiDAV {}".format(__version__)))
+            # maybe just remove the test requirement?
+            response_headers.append(("Server", "WsgiDAV/{}".format(__version__)))
             return start_response(status, response_headers, exc_info)
 
         # Call first middleware


### PR DESCRIPTION
This is a suggestion for fixing #149, maybe you can find the related cheroot issue instead, but I'm mainly using gevent.pywsgi which performs quite well so far with Flask + WsgiDAV.

Use gevent instead of cheroot for serving wsgidav:
- implemented SSL support for gevent
- changed tests to use gevent instead of cheroot
- changed documentation