### PR TITLE
Check also HTTP_X_FORWARDED_HOST as alternative to DESTINATION header

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -943,10 +943,10 @@ class RequestServer(object):
         dest_scheme = dest_scheme.lower() if dest_scheme else ""
         url_scheme = environ["wsgi.url_scheme"].lower()
         fwd_scheme = environ.get("HTTP_X_FORWARDED_PROTO", "").lower()
-        
+
         url_host = environ["HTTP_HOST"].lower()
         fwd_host = environ.get("HTTP_X_FORWARDED_HOST", "").lower()
-        
+
         if dest_scheme and dest_scheme not in (url_scheme, fwd_scheme):
             self._fail(
                 HTTP_BAD_GATEWAY,

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -943,6 +943,10 @@ class RequestServer(object):
         dest_scheme = dest_scheme.lower() if dest_scheme else ""
         url_scheme = environ["wsgi.url_scheme"].lower()
         fwd_scheme = environ.get("HTTP_X_FORWARDED_PROTO", "").lower()
+        
+        url_host = environ["HTTP_HOST"].lower()
+        fwd_host = environ.get("HTTP_X_FORWARDED_HOST", "").lower()
+        
         if dest_scheme and dest_scheme not in (url_scheme, fwd_scheme):
             self._fail(
                 HTTP_BAD_GATEWAY,
@@ -951,7 +955,7 @@ class RequestServer(object):
                 "rewrite the 'Destination' haeader.\n"
                 "(See https://github.com/mar10/wsgidav/issues/183)",
             )
-        elif dest_netloc and dest_netloc.lower() != environ["HTTP_HOST"].lower():
+        elif dest_netloc and dest_netloc not in (url_host, fwd_host):
             # TODO: this should consider environ["SERVER_PORT"] also
             self._fail(
                 HTTP_BAD_GATEWAY, "Source and destination must have the same host name."


### PR DESCRIPTION
Related to Issue #183 and pull request  #187, also the Header HTTP_X_FORWARDED_HOST has to be checked in case of a reverse proxy call. 