### PR TITLE
Append custom headers almost everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   The new option `dir_browser.davmount_links` controls link display (default: false).
 - #185 Fix FileLikeQueue for Python 3
 - #222 Discrepancy between "getetag" property and ETag header
+- #154 Improve previously not fully implemented custom headers config
 
 ## 3.1.2 / Unreleased
 

--- a/sample_wsgidav.yaml
+++ b/sample_wsgidav.yaml
@@ -39,6 +39,7 @@ port: 8080
 #: Add custom response headers (list of header-name / header-value tuples):
 # response_headers:
 #    - ["Access-Control-Allow-Origin", "http://example.org"]
+#    - ["Access-Control-Allow-Headers", "Depth"]
 
 # Transfer block size in bytes
 block_size: 8192

--- a/sample_wsgidav.yaml
+++ b/sample_wsgidav.yaml
@@ -72,6 +72,9 @@ hotfixes:
     #: there (false fixes issue #8, true fixes issue #228).
     unquote_path_info: false
 
+    #: Allow anonymous OPTIONS or not in basic/digest authentication
+    win_accept_anonymous_options: false
+
 
 # ----------------------------------------------------------------------------
 # SSL Support

--- a/wsgidav/dir_browser/_dir_browser.py
+++ b/wsgidav/dir_browser/_dir_browser.py
@@ -108,14 +108,16 @@ class WsgiDavDirBrowser(BaseMiddleware):
                 res = util.to_bytes(DAVMOUNT_TEMPLATE.format(collectionUrl))
                 # TODO: support <dm:open>%s</dm:open>
 
+                headers = [
+                    ("Content-Type", "application/davmount+xml"),
+                    ("Content-Length", str(len(res))),
+                    ("Cache-Control", "private"),
+                    ("Date", util.get_rfc1123_time()),
+                ]
+                util.append_custom_headers(environ, headers)
                 start_response(
                     "200 OK",
-                    [
-                        ("Content-Type", "application/davmount+xml"),
-                        ("Content-Length", str(len(res))),
-                        ("Cache-Control", "private"),
-                        ("Date", util.get_rfc1123_time()),
-                    ],
+                    headers,
                 )
                 return [res]
 
@@ -123,14 +125,16 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
             res = self.template.render(**context)
             res = util.to_bytes(res)
+            headers = [
+                ("Content-Type", "text/html"),
+                ("Content-Length", str(len(res))),
+                ("Cache-Control", "private"),
+                ("Date", util.get_rfc1123_time()),
+            ]
+            util.append_custom_headers(environ, headers)
             start_response(
                 "200 OK",
-                [
-                    ("Content-Type", "text/html"),
-                    ("Content-Length", str(len(res))),
-                    ("Cache-Control", "private"),
-                    ("Date", util.get_rfc1123_time()),
-                ],
+                headers,
             )
             return [res]
 

--- a/wsgidav/error_printer.py
+++ b/wsgidav/error_printer.py
@@ -96,9 +96,9 @@ class ErrorPrinter(BaseMiddleware):
             elif e.value in (HTTP_NOT_MODIFIED, HTTP_NO_CONTENT):
                 # _logger.warning("Forcing empty error response for {}".format(e.value))
                 # See paste.lint: these code don't have content
-                start_response(
-                    status, [("Content-Length", "0"), ("Date", util.get_rfc1123_time())]
-                )
+                headers = [("Content-Length", "0"), ("Date", util.get_rfc1123_time())]
+                util.append_custom_headers(environ, headers)
+                start_response(status, headers)
                 yield b""
                 return
 
@@ -107,13 +107,15 @@ class ErrorPrinter(BaseMiddleware):
             content_type, body = e.get_response_page()
 
             # TODO: provide exc_info=sys.exc_info()?
+            headers = [
+                ("Content-Type", content_type),
+                ("Content-Length", str(len(body))),
+                ("Date", util.get_rfc1123_time()),
+            ]
+            util.append_custom_headers(environ, headers)
             start_response(
                 status,
-                [
-                    ("Content-Type", content_type),
-                    ("Content-Length", str(len(body))),
-                    ("Date", util.get_rfc1123_time()),
-                ],
+                headers,
             )
             yield body
             return

--- a/wsgidav/http_authenticator.py
+++ b/wsgidav/http_authenticator.py
@@ -262,9 +262,11 @@ class HTTPAuthenticator(BaseMiddleware):
                 )
             )
 
+            headers = [("Content-Length", "0"), ("Date", util.get_rfc1123_time())]
+            util.append_custom_headers(environ, headers)
             start_response(
                 "400 Bad Request",
-                [("Content-Length", "0"), ("Date", util.get_rfc1123_time())],
+                headers,
             )
             return [""]
 
@@ -278,14 +280,16 @@ class HTTPAuthenticator(BaseMiddleware):
         wwwauthheaders = 'Basic realm="{}"'.format(realm)
 
         body = util.to_bytes(self.error_message_401)
+        headers = [
+            ("WWW-Authenticate", wwwauthheaders),
+            ("Content-Type", "text/html"),
+            ("Content-Length", str(len(body))),
+            ("Date", util.get_rfc1123_time()),
+        ]
+        util.append_custom_headers(environ, headers)
         start_response(
             "401 Not Authorized",
-            [
-                ("WWW-Authenticate", wwwauthheaders),
-                ("Content-Type", "text/html"),
-                ("Content-Length", str(len(body))),
-                ("Date", util.get_rfc1123_time()),
-            ],
+            headers,
         )
         return [body]
 
@@ -337,14 +341,16 @@ class HTTPAuthenticator(BaseMiddleware):
         )
 
         body = util.to_bytes(self.error_message_401)
+        headers = [
+            ("WWW-Authenticate", wwwauthheaders),
+            ("Content-Type", "text/html"),
+            ("Content-Length", str(len(body))),
+            ("Date", util.get_rfc1123_time()),
+        ]
+        util.append_custom_headers(environ, headers)
         start_response(
             "401 Not Authorized",
-            [
-                ("WWW-Authenticate", wwwauthheaders),
-                ("Content-Type", "text/html"),
-                ("Content-Length", str(len(body))),
-                ("Date", util.get_rfc1123_time()),
-            ],
+            headers,
         )
         return [body]
 

--- a/wsgidav/request_resolver.py
+++ b/wsgidav/request_resolver.py
@@ -198,9 +198,12 @@ class RequestResolver(BaseMiddleware):
 
             possbile_methods = util.get_possible_methods(provider)
             if possbile_methods:
+                headers.append(("Allow", ", ".join(possbile_methods)))
                 headers.append(
-                    ("Access-Control-Allow-Methods", ",".join(possbile_methods))
+                    ("Access-Control-Allow-Methods", ", ".join(possbile_methods))
                 )
+
+            util.append_custom_headers(environ, headers)
 
             start_response("200 OK", headers)
             yield b""

--- a/wsgidav/request_resolver.py
+++ b/wsgidav/request_resolver.py
@@ -196,6 +196,12 @@ class RequestResolver(BaseMiddleware):
             if environ["wsgidav.config"].get("add_header_MS_Author_Via", False):
                 headers.append(("MS-Author-Via", "DAV"))
 
+            possbile_methods = util.get_possible_methods(provider)
+            if possbile_methods:
+                headers.append(
+                    ("Access-Control-Allow-Methods", ",".join(possbile_methods))
+                )
+
             start_response("200 OK", headers)
             yield b""
             return

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -32,7 +32,8 @@ from wsgidav.dav_error import (
     as_DAVError,
     get_http_status_string,
 )
-from wsgidav.util import checked_etag, etree
+from wsgidav.util import append_custom_headers, checked_etag, etree
+
 
 __docformat__ = "reStructuredText"
 
@@ -1527,6 +1528,8 @@ class RequestServer:
         if environ["wsgidav.config"].get("add_header_MS_Author_Via", False):
             headers.append(("MS-Author-Via", "DAV"))
 
+        append_custom_headers(environ, headers)
+
         start_response("200 OK", headers)
         return [b""]
 
@@ -1640,10 +1643,7 @@ class RequestServer:
         if res.support_ranges():
             response_headers.append(("Accept-Ranges", "bytes"))
 
-        if "response_headers" in environ["wsgidav.config"]:
-            customHeaders = environ["wsgidav.config"]["response_headers"]
-            for header, value in customHeaders:
-                response_headers.append((header, value))
+        append_custom_headers(environ, response_headers)
 
         res.finalize_headers(environ, response_headers)
 

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1480,6 +1480,7 @@ class RequestServer:
             # type of method; it does nothing beyond allowing the client to test the
             # capabilities of the server. For example, this can be used to test a
             # proxy for HTTP/1.1 compliance (or lack thereof).
+            append_custom_headers(environ, headers)
             start_response("200 OK", headers)
             return [b""]
 

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -53,17 +53,7 @@ class RequestServer:
         self.block_size = DEFAULT_BLOCK_SIZE
         # _logger.debug("RequestServer: __init__")
 
-        self._possible_methods = ["OPTIONS", "HEAD", "GET", "PROPFIND"]
-        # if self._davProvider.prop_manager is not None:
-        #     self._possible_methods.extend( [ "PROPFIND" ] )
-        if not self._davProvider.is_readonly():
-            self._possible_methods.extend(
-                ["PUT", "DELETE", "COPY", "MOVE", "MKCOL", "PROPPATCH", "POST"]
-            )
-            # if self._davProvider.prop_manager is not None:
-            #     self._possible_methods.extend( [ "PROPPATCH" ] )
-            if self._davProvider.lock_manager is not None:
-                self._possible_methods.extend(["LOCK", "UNLOCK"])
+        self._possible_methods = util.get_possible_methods(self._davProvider)
 
     # def __del__(self):
     #     # _logger.debug("RequestServer: __del__")

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -870,14 +870,24 @@ def parse_xml_body(environ, *, allow_empty=False):
 #                            ])
 #    return [ body ]
 
+
 def get_possible_methods(provider):
     methods = ["OPTIONS", "HEAD", "GET", "PROPFIND"]
     if provider is None:
         # all methods are allowed because we don't find any restrictions.
-        methods.extend([
-            "PUT", "DELETE", "COPY", "MOVE", "MKCOL", "PROPPATCH", "POST",
-            "LOCK", "UNLOCK"
-        ])
+        methods.extend(
+            [
+                "PUT",
+                "DELETE",
+                "COPY",
+                "MOVE",
+                "MKCOL",
+                "PROPPATCH",
+                "POST",
+                "LOCK",
+                "UNLOCK",
+            ]
+        )
     else:
         # if provider.prop_manager is not None:
         #     methods.extend( [ "PROPFIND" ] )
@@ -892,6 +902,7 @@ def get_possible_methods(provider):
 
     return methods
 
+
 def append_custom_headers(environ, headers):
     """Add custom headers (if any configured) to a list of headers."""
     custom_headers = environ["wsgidav.config"].get("response_headers")
@@ -899,6 +910,7 @@ def append_custom_headers(environ, headers):
         for header, value in custom_headers:
             headers.append((header, value))
     return headers
+
 
 def send_status_response(
     environ, start_response, e, *, add_headers=None, is_head=False

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -870,6 +870,14 @@ def parse_xml_body(environ, *, allow_empty=False):
 #                            ])
 #    return [ body ]
 
+def append_custom_headers(environ, headers):
+    """Add custom headers (if any configured) to a list of headers."""
+    custom_headers = environ["wsgidav.config"].get("response_headers")
+    if custom_headers:
+        for header, value in custom_headers:
+            headers.append((header, value))
+    return headers
+
 
 def send_status_response(
     environ, start_response, e, *, add_headers=None, is_head=False
@@ -883,6 +891,7 @@ def send_status_response(
     #        headers += [
     #            ('Connection', 'keep-alive'),
     #        ]
+    append_custom_headers(environ, headers)
 
     if e in (HTTP_NOT_MODIFIED, HTTP_NO_CONTENT):
         # See paste.lint: these code don't have content
@@ -939,6 +948,8 @@ def send_multi_status_response(environ, start_response, multistatus_elem):
     #        headers += [
     #            ('Connection', 'keep-alive'),
     #        ]
+
+    append_custom_headers(environ, headers)
 
     start_response("207 Multi-Status", headers)
     return [xml_data]

--- a/wsgidav/util.py
+++ b/wsgidav/util.py
@@ -906,9 +906,21 @@ def get_possible_methods(provider):
 def append_custom_headers(environ, headers):
     """Add custom headers (if any configured) to a list of headers."""
     custom_headers = environ["wsgidav.config"].get("response_headers")
+
+    header_key_to_idx = {}
+    for i, header_tuple in enumerate(headers):
+        header_key_to_idx[header_tuple[0].lower()] = i
+
     if custom_headers:
         for header, value in custom_headers:
-            headers.append((header, value))
+            if header.lower() in header_key_to_idx:
+                # duplicated header found
+                # overwrite the previously set header
+                i = header_key_to_idx[header.lower()]
+                headers[i] = (header, value)
+            else:
+                # trivially append the new header tuple
+                headers.append((header, value))
     return headers
 
 


### PR DESCRIPTION
## background

I was working on a js-based webdav client, but the js-in-browser environment had cors limitation requiring some custom headers as workaround. I tried to add `response_headers` into the config file, but it didn't work as expected.

Then I found the issue https://github.com/mar10/wsgidav/issues/154 , and actually I met the same problem here. In that issue, the author started a new branch `append_custom_headers` as a potential fix, but it seems that the branch was not completed and was not merged. (And that issue was closed automatically...)

I decided the continue on that branch, and make it work.

## fix

I read through the files and added custom headers into the end of the `return`s or their common methods.

* `request_server.py`
* `request_resolver.py`
* `_dir_browsers.py`
* `http_authenticator.py`
* `error_printer.py`

## some other notes

I rebase the `append_custom_headers` branch on latest master, instead of merging the master branch. So the git history is different between https://github.com/mar10/wsgidav/tree/append_custom_headers and https://github.com/fyears/wsgidav/tree/append_custom_headers .
