### PR TITLE
Fix removing locks in recursive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.2 / Unreleased
 
+- #251 Fix removing locks in recursive mode
+
 ## 4.0.1 / 2022-01-11
 
 - #241:  Add SSL libs to MSI installer
@@ -31,8 +33,8 @@
 
 **Other changes**
 
-- Provider root paths are evaluated relative to the location of the configuration 
-  file 
+- Provider root paths are evaluated relative to the location of the configuration
+  file
 - DAVCollection, DAVNonCollection, DAVProvider are now ABCs.
 - Deprecate hotfixes.winxp_accept_root_share_login and hotfixes.win_accept_anonymous_options
 - DirBrowser supports `?davmount` URLs by default (option `dir_browser.davmount`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,7 @@
 
 **Other changes**
 
-- Provider root paths are evaluated relative to the location of the configuration
-  file
+- Provider root paths are evaluated relative to the location of the configuration file
 - DAVCollection, DAVNonCollection, DAVProvider are now ABCs.
 - Deprecate hotfixes.winxp_accept_root_share_login and hotfixes.win_accept_anonymous_options
 - DirBrowser supports `?davmount` URLs by default (option `dir_browser.davmount`).

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -850,7 +850,7 @@ class _DAVResource(ABC):
             return False
         return self.provider.lock_manager.is_url_locked(self.get_ref_url())
 
-    def remove_all_locks(self, *, recursive=False):
+    def remove_all_locks(self, *, recursive):
         if self.provider.lock_manager:
             self.provider.lock_manager.remove_all_locks_from_url(self.get_ref_url(), recursive=recursive)
 

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -850,9 +850,9 @@ class _DAVResource(ABC):
             return False
         return self.provider.lock_manager.is_url_locked(self.get_ref_url())
 
-    def remove_all_locks(self, *, recursive):
+    def remove_all_locks(self, *, recursive=False):
         if self.provider.lock_manager:
-            self.provider.lock_manager.remove_all_locks_from_url(self.get_ref_url())
+            self.provider.lock_manager.remove_all_locks_from_url(self.get_ref_url(), recursive=recursive)
 
     # --- Read / write -------------------------------------------------------
 

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -852,7 +852,9 @@ class _DAVResource(ABC):
 
     def remove_all_locks(self, *, recursive):
         if self.provider.lock_manager:
-            self.provider.lock_manager.remove_all_locks_from_url(self.get_ref_url(), recursive=recursive)
+            self.provider.lock_manager.remove_all_locks_from_url(
+                self.get_ref_url(), recursive=recursive
+            )
 
     # --- Read / write -------------------------------------------------------
 

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -104,8 +104,8 @@ class FileResource(DAVNonCollection):
         if self.provider.readonly:
             raise DAVError(HTTP_FORBIDDEN)
         os.unlink(self._file_path)
-        self.remove_all_properties(recursive=True)
-        self.remove_all_locks(recursive=True)
+        self.remove_all_properties(recursive=False)
+        self.remove_all_locks(recursive=False)
 
     def copy_move_single(self, dest_path, *, is_move):
         """See DAVResource.copy_move_single()"""

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -104,8 +104,8 @@ class FileResource(DAVNonCollection):
         if self.provider.readonly:
             raise DAVError(HTTP_FORBIDDEN)
         os.unlink(self._file_path)
-        self.remove_all_properties(recursive=False)
-        self.remove_all_locks(recursive=False)
+        self.remove_all_properties(recursive=True)
+        self.remove_all_locks(recursive=True)
 
     def copy_move_single(self, dest_path, *, is_move):
         """See DAVResource.copy_move_single()"""

--- a/wsgidav/lock_man/lock_manager.py
+++ b/wsgidav/lock_man/lock_manager.py
@@ -278,7 +278,7 @@ class LockManager:
         """Return True, if <token> exists, is valid, and bound to <principal>."""
         return self.get_lock(token, key="principal") == principal
 
-    def get_url_lock_list(self, url, recursive=False):
+    def get_url_lock_list(self, url, *, recursive=False):
         """Return list of lock_dict, if <url> is protected by at least one direct, valid lock.
 
         Side effect: expired locks for this url are purged.
@@ -324,7 +324,7 @@ class LockManager:
         lockUrl = self.get_lock(lock_token, key="root")
         return lockUrl and util.is_equal_or_child_uri(lockUrl, url)
 
-    def remove_all_locks_from_url(self, url, recursive=False):
+    def remove_all_locks_from_url(self, url, *, recursive=False):
         self._lock.acquire_write()
         try:
             lockList = self.get_url_lock_list(url, recursive=recursive)

--- a/wsgidav/lock_man/lock_manager.py
+++ b/wsgidav/lock_man/lock_manager.py
@@ -278,14 +278,14 @@ class LockManager:
         """Return True, if <token> exists, is valid, and bound to <principal>."""
         return self.get_lock(token, key="principal") == principal
 
-    def get_url_lock_list(self, url):
+    def get_url_lock_list(self, url, recursive=False):
         """Return list of lock_dict, if <url> is protected by at least one direct, valid lock.
 
         Side effect: expired locks for this url are purged.
         """
         url = normalize_lock_root(url)
         lockList = self.storage.get_lock_list(
-            url, include_root=True, include_children=False, token_only=False
+            url, include_root=True, include_children=recursive, token_only=False
         )
         return lockList
 
@@ -324,10 +324,10 @@ class LockManager:
         lockUrl = self.get_lock(lock_token, key="root")
         return lockUrl and util.is_equal_or_child_uri(lockUrl, url)
 
-    def remove_all_locks_from_url(self, url):
+    def remove_all_locks_from_url(self, url, recursive=False):
         self._lock.acquire_write()
         try:
-            lockList = self.get_url_lock_list(url)
+            lockList = self.get_url_lock_list(url, recursive=recursive)
             for lock in lockList:
                 self.release(lock["token"])
         finally:


### PR DESCRIPTION
Surely an oversight, in the recursive mode the child locks must be deleted. The "recursive" parameter must therefore be taken into account in the `get_url_lock_list` function 