### PR TITLE
Use the required dry_run keyword argument when calling set_last_modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - #251 Fix removing locks in recursive mode
 - #255 Fix ERROR: Invalid requirement: 'cheroot~=8'
 - #260 Fix Case-Sensitivity issue on MOVE/COPY actions through Windows DAV
+- #261 Use the required dry_run keyword argument when calling set_last_modified
 
 ## 4.0.1 / 2022-01-11
 

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -786,7 +786,9 @@ class _DAVResource(ABC):
             # commands.
             if name in ("{DAV:}getlastmodified", "{DAV:}last_modified"):
                 try:
-                    return self.set_last_modified(self.path, value.text, dry_run=dry_run)
+                    return self.set_last_modified(
+                        self.path, value.text, dry_run=dry_run
+                    )
                 except Exception:
                     _logger.warning(
                         "Provider does not support set_last_modified on {}.".format(
@@ -806,7 +808,9 @@ class _DAVResource(ABC):
             win32_emu = hotfixes.get("emulate_win32_lastmod", False)
             if win32_emu and "MiniRedir/6.1" not in agent:
                 if "Win32LastModifiedTime" in name:
-                    return self.set_last_modified(self.path, value.text, dry_run=dry_run)
+                    return self.set_last_modified(
+                        self.path, value.text, dry_run=dry_run
+                    )
                 elif "Win32FileAttributes" in name:
                     return True
                 elif "Win32CreationTime" in name:

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -786,7 +786,7 @@ class _DAVResource(ABC):
             # commands.
             if name in ("{DAV:}getlastmodified", "{DAV:}last_modified"):
                 try:
-                    return self.set_last_modified(self.path, value.text, dry_run)
+                    return self.set_last_modified(self.path, value.text, dry_run=dry_run)
                 except Exception:
                     _logger.warning(
                         "Provider does not support set_last_modified on {}.".format(
@@ -806,7 +806,7 @@ class _DAVResource(ABC):
             win32_emu = hotfixes.get("emulate_win32_lastmod", False)
             if win32_emu and "MiniRedir/6.1" not in agent:
                 if "Win32LastModifiedTime" in name:
-                    return self.set_last_modified(self.path, value.text, dry_run)
+                    return self.set_last_modified(self.path, value.text, dry_run=dry_run)
                 elif "Win32FileAttributes" in name:
                     return True
                 elif "Win32CreationTime" in name:


### PR DESCRIPTION
This change restores the ability to set the last modified date with getlastmodified within WinSCP and CarotDAV. Issue was first discussed in #248 

I might be completely off-base with this solution. I'm unsure how it was working correctly under any client without specifying the keyword.