### PR TITLE
Fix return type annotation on `get_creation_date()`

### DIFF
--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -220,7 +220,7 @@ class _DAVResource(ABC):
             return None
         raise NotImplementedError
 
-    def get_creation_date(self) -> Optional[datetime]:
+    def get_creation_date(self) -> Optional[float]:
         """Records the time and date the resource was created.
 
         The creationdate property should be defined on all DAV compliant

--- a/wsgidav/dav_provider.py
+++ b/wsgidav/dav_provider.py
@@ -84,7 +84,6 @@ import sys
 import time
 import traceback
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import Optional
 from urllib.parse import quote, unquote
 


### PR DESCRIPTION
`_DAVResource.get_creation_date()` is annotated as returning `Optional[datetime]`, but `_DAVResources.get_property_value()` passes the method's return value to `get_rfc3339_time()`, which requires a Unix timestamp instead.