### PR TITLE
User-List Control for PAM Authentication

### DIFF
--- a/docs/source/user_guide_configure.rst
+++ b/docs/source/user_guide_configure.rst
@@ -416,6 +416,11 @@ known user accounts::
 
     pam_dc:
         service: "login"
+        allow_users: "all"
+        #: or "current" for the current user, or a list of user names like deny_users
+        # deny_users:
+        #   - "root"
+        #   - "daemon"
 
 If no config file is used, PAM authentication can be enabled on the command
 line like::

--- a/wsgidav/dc/pam_dc.py
+++ b/wsgidav/dc/pam_dc.py
@@ -39,11 +39,15 @@ class PAMDomainController(BaseDomainController):
         self.pam_encoding = dc_conf.get("encoding", "utf-8")
         self.pam_resetcreds = dc_conf.get("resetcreds", True)
         self.allow_users = dc_conf.get("allow_users", "all")
-        assert self.allow_users in ("all", "current") or isinstance(self.allow_users, list), \
-            f"Invalid 'allow_users' value: {self.allow_users!r}, expected 'all', 'current' or list of allowed users."
+        if not (self.allow_users in ("all", "current") or isinstance(self.allow_users, list)):
+            raise ValueError(
+                f"Invalid 'allow_users' value: {self.allow_users!r}, expected 'all', 'current' or list of allowed users."
+            )
         self.deny_users = dc_conf.get("deny_users", [])
-        assert isinstance(self.deny_users, list), \
-            f"Invalid 'deny_users' value: {self.deny_users!r}, expected list of denied users."
+        if not isinstance(self.deny_users, list):
+            raise ValueError(
+                f"Invalid 'deny_users' value: {self.deny_users!r}, expected list of denied users."
+            )
 
     def __str__(self):
         return f"{self.__class__.__name__}({self.pam_service!r})"


### PR DESCRIPTION
In the current implementation, PAM authentication in wsgidav only checks if a user exists on the OS. The new patch introduces a user-list control feature, allowing more granular management of which users can access the WebDAV service.

### Key Features
1. **`deny_users` Option**:  
   A `list[str]` that explicitly denies login access to any users listed. This option has the highest priority. If a user is listed in `deny_users`, they will be blocked from logging in, regardless of other settings.

2. **`allow_users` Option**:  
   Can be set as a `str` or `list[str]`, determining which users are allowed to log in:
   - **"all" (default)**: All users on the OS are permitted.
   - **"current"**: Only the user running the wsgidav program can log in.
   - A specific list of users can also be provided to explicitly allow access.

### Compatibility
This user-list control does not change the default behavior, which allows all OS users to log in.