### PR TITLE
Add note for gunicorn workers to `sample_wsgidav.yaml`

### DIFF
--- a/sample_wsgidav.yaml
+++ b/sample_wsgidav.yaml
@@ -16,6 +16,10 @@
 #: used in production.
 #: All other servers must have been installed before, e.g. `pip install cheroot`.
 #: (The binary MSI distribution already includes 'cheroot'.)
+#: NOTE: Using 'gunicorn' with more than 1 worker can cause problems with the
+#: in-memory and shelve-based lock storage as both are not safe for concurrent
+#: access. (see issue #332) Instead, you can use 'gunicorn' with multiple `threads`
+#: or try the 'redis' based lock storage (#186).
 #: Default: 'cheroot', use the `--server` command line option to change this.
 
 server: cheroot


### PR DESCRIPTION
In response to #332, I added a note for `gunicorn` to the `sample_wsgidav.yaml`. I guess, this is sufficient to indicate incompatibilities with certain `gunicorn` settings.

Closes #332