### PR TITLE
optionally set file/directory modification time when x-oc-mtime header presence

### DIFF
--- a/sample_wsgidav.yaml
+++ b/sample_wsgidav.yaml
@@ -151,6 +151,9 @@ fs_dav_provider:
     #: Serve symbolic link files and folders (default: false)
     follow_symlinks: false
 
+#: Set last modification based on timestamp provided by `X-OC-Mtime` header
+honor_mtime_header: false
+
 # ==============================================================================
 # AUTHENTICATION
 http_authenticator:

--- a/wsgidav/default_conf.py
+++ b/wsgidav/default_conf.py
@@ -41,6 +41,7 @@ DEFAULT_CONFIG = {
         "shadow_map": {},
         "follow_symlinks": False,
     },
+    "honor_mtime_header": False,
     "add_header_MS_Author_Via": True,
     "hotfixes": {
         "emulate_win32_lastmod": False,  # True: support Win32LastModifiedTime

--- a/wsgidav/fs_dav_provider.py
+++ b/wsgidav/fs_dav_provider.py
@@ -163,7 +163,8 @@ class FileResource(DAVNonCollection):
     def set_last_modified(self, dest_path, time_stamp, *, dry_run):
         """Set last modified time for destPath to timeStamp on epoch-format"""
         # Translate time from RFC 1123 to seconds since epoch format
-        secs = util.parse_time_string(time_stamp)
+        secs = time_stamp if isinstance(time_stamp, int) else util.parse_time_string(time_stamp)
+        assert(isinstance(secs, int))
         if not dry_run:
             os.utime(self._file_path, (secs, secs))
         return True
@@ -365,7 +366,8 @@ class FolderResource(DAVCollection):
     def set_last_modified(self, dest_path, time_stamp, *, dry_run):
         """Set last modified time for destPath to timeStamp on epoch-format"""
         # Translate time from RFC 1123 to seconds since epoch format
-        secs = util.parse_time_string(time_stamp)
+        secs = time_stamp if isinstance(time_stamp, int) else util.parse_time_string(time_stamp)
+        assert(isinstance(secs, int))
         if not dry_run:
             os.utime(self._file_path, (secs, secs))
         return True


### PR DESCRIPTION
WebDAV specification has no standard approach to set modification time [mtime] of files or directories on server.

one unofficial implementation is owncloud's (predecessor of [nextcloud](https://nextcloud.com/)) `x-oc-mtime` header, which containes an non-negative decimal integer represents the unix timestamp of `mtime` of the webdav resource which is manipulated by the client. this implementation also shown up in non-nextcloud implementations says [rclone](https://github.com/rclone/rclone/blob/3f0e9f5fca8080f87094341f8ac5027091cc7601/cmd/serve/webdav/webdav.go#L339).

this patch adds a new configuration `honor_mtime_header`, which defaults to `False` to avoid introduction of breaking changes.

upon enabling of this option, wsgidav would check if `x-oc-mtime` header exists on `PUT` and `MKCOL` request methods, if so and the value is valid, it would call modified version of `set_last_modified()` which allows raw unix timestamps to set `mtime` for files/directories.

the request is rejected with a 400 bad request in case of an invalid value of `x-oc-mtime`.