### PR TITLE
feat: impersonator middleware feature/usability improvements

### DIFF
--- a/sample_wsgidav.yaml
+++ b/sample_wsgidav.yaml
@@ -234,6 +234,9 @@ impersonator:
     # or, use WebDAV (HTTP) usernames as is
     custom_user_mapping: null
 
+    # do not allow impersonating as system users (UID <= 999)
+    reject_system_users: false
+
 
 # ----------------------------------------------------------------------------
 # CORS

--- a/suid-wrapper.c
+++ b/suid-wrapper.c
@@ -1,0 +1,60 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <cap-ng.h>
+#include <errno.h>
+#include <pwd.h>
+
+int
+main(int argc, char *argv[], char *envp[])
+{
+	int ret;
+	struct passwd *pwd = NULL;
+	uid_t uid;
+	gid_t gid;
+
+	if (argc <= 2) {
+		fprintf(stderr, "usage: %s user cmd argv [argv]\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	errno = 0;
+	if ((pwd = getpwnam(argv[1])) == NULL) {
+		if (errno != 0) perror("getpanam");
+		else fprintf(stderr, "getpwnam: can not find user %s\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	uid = pwd->pw_uid;
+	gid = pwd->pw_gid;
+
+	if (uid == 0) {
+		fprintf(stderr, "can not run as root (uid = 0)\n");
+		return EXIT_FAILURE;
+	}
+
+	capng_clear(CAPNG_SELECT_BOTH);
+
+	ret = capng_updatev(CAPNG_ADD,
+		CAPNG_EFFECTIVE | CAPNG_PERMITTED | CAPNG_INHERITABLE | CAPNG_AMBIENT,
+		CAP_SETUID, CAP_SETGID, -1);
+	if (ret < 0) {
+		fprintf(stderr, "capng_updatev() returns %d\n", ret);
+		return EXIT_FAILURE;
+	}
+
+	ret = capng_change_id(uid, gid, CAPNG_INIT_SUPP_GRP);
+	if (ret < 0) {
+		fprintf(stderr, "capng_change_id() returns %d\n", ret);
+		return EXIT_FAILURE;
+	}
+
+	errno = 0;
+	if (execvpe(argv[2], &argv[2], envp) < 0) {
+		perror("execvpe");
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/wsgidav/mw/impersonator.py
+++ b/wsgidav/mw/impersonator.py
@@ -18,7 +18,6 @@ restored.
 import os
 import pwd
 from contextlib import AbstractContextManager
-from typing import Tuple
 
 from wsgidav import util
 from wsgidav.mw.base_mw import BaseMiddleware
@@ -100,6 +99,12 @@ class Impersonator(BaseMiddleware):
 
         try:
             passwd = pwd.getpwnam(unix_username)
+            if self.get_config("impersonator.reject_system_users", False) and passwd.pw_uid <= 999:
+                raise ValueError
+        except ValueError:
+            raise RuntimeError(
+                f"Unix user '{unix_username}' is a system user, impersonating rejected"
+            ) from None
         except Exception:
             raise RuntimeError(
                 f"Unix username '{unix_username}' does not exist"

--- a/wsgidav/mw/impersonator.py
+++ b/wsgidav/mw/impersonator.py
@@ -24,44 +24,43 @@ from wsgidav import util
 from wsgidav.mw.base_mw import BaseMiddleware
 
 _logger = util.get_module_logger(__name__)
-_init_euid = os.geteuid()
-_init_egid = os.getegid()
-_logger.debug(f"impersonator: initial uid:gid = {_init_euid}:{_init_egid}")
+_init_pwd = pwd.getpwuid(os.geteuid())
+_logger.debug(f"impersonator: initial uid:gid = {_init_pwd.pw_uid}:{_init_pwd.pw_gid}")
 
 
 class ImpersonateContext(AbstractContextManager):
-    def __init__(self, ids: Tuple[int, int] | None) -> None:
-        if ids is None:
+    def __init__(self, pwd: pwd.struct_passwd | None) -> None:
+        if pwd is None:
             self._enabled = False
             return
-        self._enabled = True
-        self._new_euid = ids[0]
-        self._new_egid = ids[1]
-        self._old_euid = os.geteuid()
-        self._old_egid = os.getegid()
 
-        if self._old_euid != _init_euid or self._old_egid != _init_egid:
+        self._enabled = True
+        self._pwd = pwd
+
+        if os.geteuid() != _init_pwd.pw_uid or os.getegid() != _init_pwd.pw_gid:
             raise Exception(
-                "old ids mismatched with init ids: "
-                f"{self._old_euid}:{self._old_egid} versus {_init_euid}:{_init_egid}, "
+                "current ids mismatched with init ids: "
+                f"{os.geteuid()}:{os.getegid()} versus {_init_pwd.pw_uid}:{_init_pwd.pw_gid}, "
                 "multithreading MUST be disabled for impersonator to function correctly"
             )
 
     def __enter__(self):
         if not self._enabled:
             return
-        os.seteuid(self._new_euid)
-        os.setegid(self._new_egid)
-        _logger.debug(f"impersonator: set uid:gid = {self._new_euid}:{self._new_egid}")
+        os.seteuid(self._pwd.pw_uid)
+        os.setegid(self._pwd.pw_gid)
+        os.initgroups(self._pwd.pw_name, self._pwd.pw_gid)
+        _logger.debug(f"impersonator: set uid:gid = {os.geteuid()}:{os.getegid()}")
+        _logger.debug(f"impersonator: set groups = {os.getgroups()}")
 
     def __exit__(self, exc_type, exc_value, traceback, /):
         if not self._enabled:
             return
-        os.seteuid(self._old_euid)
-        os.setegid(self._old_egid)
-        _logger.debug(
-            f"impersonator: reset uid:gid = {self._old_euid}:{self._old_egid}"
-        )
+        os.seteuid(_init_pwd.pw_uid)
+        os.setegid(_init_pwd.pw_gid)
+        os.initgroups(_init_pwd.pw_name, _init_pwd.pw_gid)
+        _logger.debug(f"impersonator: reset uid:gid = {os.geteuid()}:{os.getegid()}")
+        _logger.debug(f"impersonator: reset groups = {os.getgroups()}")
 
 
 class Impersonator(BaseMiddleware):
@@ -77,7 +76,7 @@ class Impersonator(BaseMiddleware):
     def is_disabled(self):  # type: ignore
         return not self.get_config("impersonator.enable", False)  # type: ignore
 
-    def _map_id(self, username: str) -> Tuple[int, int] | None:
+    def _map_id(self, username: str) -> pwd.struct_passwd | None:
         if self.is_disabled():
             return None
 
@@ -93,9 +92,7 @@ class Impersonator(BaseMiddleware):
             )  # type: ignore
 
         if unix_username is None:
-            raise RuntimeError(
-                f"Failed mapping HTTP username '{username}' to Unix username"
-            )
+            raise RuntimeError(f"Failed mapping HTTP username '{username}' to Unix username")
 
         _logger.debug(
             f"impersonator: HTTP user {username or '(anonymous)'} -> Unix user {unix_username}"
@@ -108,7 +105,4 @@ class Impersonator(BaseMiddleware):
                 f"Unix username '{unix_username}' does not exist"
             ) from None
         else:
-            _logger.debug(
-                f"impersonator: Unix user {unix_username} -> uid:gid = {passwd.pw_uid}:{passwd.pw_gid}"
-            )
-            return (passwd.pw_uid, passwd.pw_gid)
+            return passwd


### PR DESCRIPTION
this patch tackles 3 major issues of the current implementation of impersonator:

### 1. handling additional groups

unix users could retrieve groups they belongs with `id` command, it is common that a user belongs to multiple additional groups than the one which named identical to him/herself. here below is an example retrieving my groups on my linux workstation:

```
$ id
uid=1000(leo) gid=1000(leo) groups=1000(leo),150(wireshark),970(libvirt),971(docker),998(wheel)
```

the current implementation, wsgidav only call `os.setegid(1000)` when impersonating as `leo` on this machine, while other groups, incl. `wireshark`, `docker`, etc, should also be added.

this patch handles such cases with `os.initgroups()` to properly add additional groups accordingly (to `/etc/group`) when impersonating.

### 2. rejecting system users

uids <= 999 on unix systems are generally preserved for system daemon uses, a sysadmin may not want someone being capable to impersonate as such users. (probably due to misconfiguration of domain controller, etc)

this patch adds an option to reject impersonating-as-system-users attemps:

```
impersonator:
    reject_system_users: true
```

### 3. docker capability issues

docker's `--cap-add` (or `cap_add:` in docker-compose.yml) does not add the capabilities to the ambient set, therefore the capability is dropped upon `fork()`/`execve()`, (which is behind gunicorn's worker spawning) rendering the approach described in https://github.com/mar10/wsgidav/issues/343#issuecomment-3028042499 not feasible.

this patch included a statically-linked helper program in C to achieve this in containers.

```
suid-wrapper nobody wsgidav -c /path/to/wsgidav.yaml
```