### PR TITLE
restore Python 3.9 compatibility

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,37 @@
+# (c) 2009-2026 Martin Wendt and contributors; see WsgiDAV https://github.com/mar10/wsgidav
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license.php
+"""Smoke test that asserts that every module can be imported."""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import wsgidav
+
+
+def _reraise(module_name):
+    raise
+
+
+MODULE_NAMES = sorted(
+    info.name
+    # reraise ensures that import errors of subpackages are not silently ignored
+    for info in pkgutil.walk_packages(wsgidav.__path__, "wsgidav.", onerror=_reraise)
+)
+
+
+def test_finds_at_least_some_modules():
+    assert len(MODULE_NAMES) > 10
+
+
+@pytest.mark.parametrize("module_name", MODULE_NAMES)
+def test_module_is_importable(module_name):
+    try:
+        importlib.import_module(module_name)
+    except ImportError as e:
+        # accept missing optional or platform specific dependencies,
+        if e.name and e.name.partition(".")[0] == "wsgidav":
+            raise
+        pytest.skip(f"missing dependency {e.name!r}")

--- a/wsgidav/mw/impersonator.py
+++ b/wsgidav/mw/impersonator.py
@@ -18,7 +18,7 @@ restored.
 import os
 import pwd
 from contextlib import AbstractContextManager
-from typing import Tuple
+from typing import Optional, Tuple
 
 from wsgidav import util
 from wsgidav.mw.base_mw import BaseMiddleware
@@ -30,7 +30,7 @@ _logger.debug(f"impersonator: initial uid:gid = {_init_euid}:{_init_egid}")
 
 
 class ImpersonateContext(AbstractContextManager):
-    def __init__(self, ids: Tuple[int, int] | None) -> None:
+    def __init__(self, ids: Optional[Tuple[int, int]]) -> None:
         if ids is None:
             self._enabled = False
             return
@@ -77,7 +77,7 @@ class Impersonator(BaseMiddleware):
     def is_disabled(self):  # type: ignore
         return not self.get_config("impersonator.enable", False)  # type: ignore
 
-    def _map_id(self, username: str) -> Tuple[int, int] | None:
+    def _map_id(self, username: str) -> Optional[Tuple[int, int]]:
         if self.is_disabled():
             return None
 


### PR DESCRIPTION
` | None` is only valid for Python 3.10+.