### PR TITLE
HEAD requests shouldn't return body on error

### DIFF
--- a/wsgidav/dav_error.py
+++ b/wsgidav/dav_error.py
@@ -230,7 +230,7 @@ class DAVError(Exception):
             s = f"{self.value}"
 
         if self.context_info and self.context_info.get("text") is not None:
-            s += f": {self.context_info.text}"
+            s += f": {self.context_info["text"]}"
         elif self.value in ERROR_RESPONSES:
             s += f": {ERROR_RESPONSES[self.value]}"
 

--- a/wsgidav/dav_error.py
+++ b/wsgidav/dav_error.py
@@ -229,8 +229,8 @@ class DAVError(Exception):
         else:
             s = f"{self.value}"
 
-        if self.context_info:
-            s += f": {self.context_info}"
+        if self.context_info and self.context_info.get("text") is not None:
+            s += f": {self.context_info.text}"
         elif self.value in ERROR_RESPONSES:
             s += f": {ERROR_RESPONSES[self.value]}"
 

--- a/wsgidav/dir_browser/_dir_browser.py
+++ b/wsgidav/dir_browser/_dir_browser.py
@@ -146,7 +146,7 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
     def _fail(self, value, context_info_text=None, src_exception=None, err_condition=None):
         """Wrapper to raise (and log) DAVError."""
-        e = DAVError(value, context_info={"text": context_info_text}, src_exception, err_condition)
+        e = DAVError(value, context_info={"text": context_info_text}, src_exception=src_exception, err_condition=err_condition)
         if self.verbose >= 4:
             _logger.warning(
                 f"Raising DAVError {safe_re_encode(e.get_user_info(), sys.stdout.encoding)}"

--- a/wsgidav/dir_browser/_dir_browser.py
+++ b/wsgidav/dir_browser/_dir_browser.py
@@ -144,9 +144,9 @@ class WsgiDavDirBrowser(BaseMiddleware):
 
         return self.next_app(environ, start_response)
 
-    def _fail(self, value, context_info=None, src_exception=None, err_condition=None):
+    def _fail(self, value, context_info_text=None, src_exception=None, err_condition=None):
         """Wrapper to raise (and log) DAVError."""
-        e = DAVError(value, context_info, src_exception, err_condition)
+        e = DAVError(value, context_info={"text": context_info_text}, src_exception, err_condition)
         if self.verbose >= 4:
             _logger.warning(
                 f"Raising DAVError {safe_re_encode(e.get_user_info(), sys.stdout.encoding)}"

--- a/wsgidav/error_printer.py
+++ b/wsgidav/error_printer.py
@@ -106,6 +106,14 @@ class ErrorPrinter(BaseMiddleware):
                 yield b""
                 return
 
+            if (
+                 e.context_info
+                 and e.context_info.get("text") is not None
+                 and e.context_info["is_header_method"]
+            ):
+                yield b""
+                return
+
             # If exception has pre-/post-condition: return as XML response,
             # else return as HTML
             content_type, body = e.get_response_page()

--- a/wsgidav/error_printer.py
+++ b/wsgidav/error_printer.py
@@ -106,14 +106,6 @@ class ErrorPrinter(BaseMiddleware):
                 yield b""
                 return
 
-            if (
-                 e.context_info
-                 and e.context_info.get("text") is not None
-                 and e.context_info["is_header_method"]
-            ):
-                yield b""
-                return
-
             # If exception has pre-/post-condition: return as XML response,
             # else return as HTML
             content_type, body = e.get_response_page()
@@ -128,5 +120,14 @@ class ErrorPrinter(BaseMiddleware):
                 ]
                 + headers,
             )
+
+            if (
+                 e.context_info
+                 and e.context_info.get("is_head_method") is not None
+                 and e.context_info["is_head_method"]
+            ):
+                yield b""
+                return
+
             yield body
             return

--- a/wsgidav/http_authenticator.py
+++ b/wsgidav/http_authenticator.py
@@ -339,7 +339,7 @@ class HTTPAuthenticator(BaseMiddleware):
         if not realm:
             raise DAVError(
                 HTTP_NOT_FOUND,
-                context_info=f"Could not resolve realm for {environ['PATH_INFO']}",
+                context_info={"text": f"Could not resolve realm for {environ['PATH_INFO']}"},
             )
 
         is_invalid_req = False

--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -142,11 +142,11 @@ class RequestServer:
                 app_iter.close()
         return
 
-    def _fail(self, value, context_info=None, src_exception=None, err_condition=None):
+    def _fail(self, value, context_info_text=None, src_exception=None, err_condition=None, is_head_method=False):
         """Wrapper to raise (and log) DAVError."""
         util.fail(
             value,
-            context_info,
+            context_info={"text": context_info_text, "is_head_method": is_head_method},
             src_exception=src_exception,
             err_condition=err_condition,
         )
@@ -1484,7 +1484,7 @@ class RequestServer:
         elif environ.setdefault("HTTP_DEPTH", "0") != "0":
             self._fail(HTTP_BAD_REQUEST, "Only Depth: 0 supported.")
         elif res is None:
-            self._fail(HTTP_NOT_FOUND, path)
+            self._fail(HTTP_NOT_FOUND, path, is_head_method=is_head_method)
         elif res.is_collection:
             self._fail(
                 HTTP_FORBIDDEN,


### PR DESCRIPTION
Prevents body from being added on error reponse.
It doesn't handle all errors. Maybe it's not a good idea to use context_info in that way across mw. Pls take it as wip.
Thanks